### PR TITLE
✨ Group conditional availabilities by generated key

### DIFF
--- a/bundles/conditional-availability-bulk-api/src/FondOfImpala/Shared/ConditionalAvailabilityBulkApi/Transfer/conditional_availability_bulk_api.transfer.xml
+++ b/bundles/conditional-availability-bulk-api/src/FondOfImpala/Shared/ConditionalAvailabilityBulkApi/Transfer/conditional_availability_bulk_api.transfer.xml
@@ -8,7 +8,6 @@
         <property name="isSuccessful" type="bool"/>
     </transfer>
 
-
     <transfer name="ConditionalAvailabilityBulkApiResponse">
         <property name="conditionalAvailabilityIds" singular="conditionalAvailabilityId" type="int[]" />
     </transfer>

--- a/bundles/conditional-availability-bulk-api/src/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/ConditionalAvailabilityBulkApiBusinessFactory.php
+++ b/bundles/conditional-availability-bulk-api/src/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/ConditionalAvailabilityBulkApiBusinessFactory.php
@@ -2,6 +2,8 @@
 
 namespace FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business;
 
+use FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator\GroupKeyGenerator;
+use FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator\GroupKeyGeneratorInterface;
 use FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Mapper\ConditionalAvailabilityBulkApiMapper;
 use FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Mapper\ConditionalAvailabilityBulkApiMapperInterface;
 use FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Model\ConditionalAvailabilityBulkApi;
@@ -63,6 +65,16 @@ class ConditionalAvailabilityBulkApiBusinessFactory extends AbstractBusinessFact
      */
     protected function createConditionalAvailabilityBulkApiMapper(): ConditionalAvailabilityBulkApiMapperInterface
     {
-        return new ConditionalAvailabilityBulkApiMapper();
+        return new ConditionalAvailabilityBulkApiMapper(
+            $this->createGroupKeyGenerator(),
+        );
+    }
+
+    /**
+     * @return \FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator\GroupKeyGeneratorInterface
+     */
+    protected function createGroupKeyGenerator(): GroupKeyGeneratorInterface
+    {
+        return new GroupKeyGenerator();
     }
 }

--- a/bundles/conditional-availability-bulk-api/src/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Generator/GroupKeyGenerator.php
+++ b/bundles/conditional-availability-bulk-api/src/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Generator/GroupKeyGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator;
+
+class GroupKeyGenerator implements GroupKeyGeneratorInterface
+{
+    /**
+     * @var array<string>
+     */
+    public const REQUIRED_API_DATA_KEYS = [
+        'warehouse_group',
+    ];
+
+    /**
+     * @param array $apiData
+     *
+     * @return string|null
+     */
+    public function generateByApiData(array $apiData): ?string
+    {
+        $groupKeyParts = [];
+
+        foreach (static::REQUIRED_API_DATA_KEYS as $dataKey) {
+            if (!isset($apiData[$dataKey])) {
+                return null;
+            }
+
+            $groupKeyParts[] = $apiData[$dataKey];
+        }
+
+        return sha1(implode('-', $groupKeyParts));
+    }
+}

--- a/bundles/conditional-availability-bulk-api/src/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Generator/GroupKeyGeneratorInterface.php
+++ b/bundles/conditional-availability-bulk-api/src/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Generator/GroupKeyGeneratorInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator;
+
+interface GroupKeyGeneratorInterface
+{
+    /**
+     * @param array $apiData
+     *
+     * @return string|null
+     */
+    public function generateByApiData(array $apiData): ?string;
+}

--- a/bundles/conditional-availability-bulk-api/tests/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Generator/GroupKeyGeneratorTest.php
+++ b/bundles/conditional-availability-bulk-api/tests/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Generator/GroupKeyGeneratorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator;
+
+use Codeception\Test\Unit;
+
+class GroupKeyGeneratorTest extends Unit
+{
+    /**
+     * @var \FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator\GroupKeyGenerator
+     */
+    protected GroupKeyGenerator $groupKeyGenerator;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->groupKeyGenerator = new GroupKeyGenerator();
+    }
+
+    /**
+     * @return void
+     */
+    public function testGenerateByApiData(): void
+    {
+        $apiData = [
+            'sku' => 'FOO-1',
+            'warehouse_group' => 'FOO',
+        ];
+
+        static::assertEquals(
+            sha1($apiData['warehouse_group']),
+            $this->groupKeyGenerator->generateByApiData($apiData),
+        );
+    }
+}

--- a/bundles/conditional-availability-bulk-api/tests/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Mapper/ConditionalAvailabilityBulkApiMapperTest.php
+++ b/bundles/conditional-availability-bulk-api/tests/FondOfImpala/Zed/ConditionalAvailabilityBulkApi/Business/Mapper/ConditionalAvailabilityBulkApiMapperTest.php
@@ -3,12 +3,18 @@
 namespace FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Mapper;
 
 use Codeception\Test\Unit;
+use FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator\GroupKeyGeneratorInterface;
 use Generated\Shared\Transfer\ApiDataTransfer;
 use Generated\Shared\Transfer\ConditionalAvailabilityTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ConditionalAvailabilityBulkApiMapperTest extends Unit
 {
+    /**
+     * @var (\FondOfImpala\Zed\ConditionalAvailabilityBulkApi\Business\Generator\GroupKeyGeneratorInterface&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected MockObject|GroupKeyGeneratorInterface $groupKeyGeneratorMock;
+
     /**
      * @var (\Generated\Shared\Transfer\ApiDataTransfer&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
      */
@@ -28,11 +34,17 @@ class ConditionalAvailabilityBulkApiMapperTest extends Unit
     {
         parent::_before();
 
+        $this->groupKeyGeneratorMock = $this->getMockBuilder(GroupKeyGeneratorInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->apiDataTransferMock = $this->getMockBuilder(ApiDataTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->conditionalAvailabilityBulkApiMapper = new ConditionalAvailabilityBulkApiMapper();
+        $this->conditionalAvailabilityBulkApiMapper = new ConditionalAvailabilityBulkApiMapper(
+            $this->groupKeyGeneratorMock,
+        );
     }
 
     /**
@@ -45,23 +57,35 @@ class ConditionalAvailabilityBulkApiMapperTest extends Unit
             ['sku' => 'FOO-2'],
         ];
 
+        $groupKey = sha1($data[0]['warehouse_group']);
+
         $this->apiDataTransferMock->expects(static::atLeastOnce())
             ->method('getData')
             ->willReturn($data);
+
+        $this->groupKeyGeneratorMock->expects(static::atLeastOnce())
+            ->method('generateByApiData')
+            ->withConsecutive(
+                [$data[0]],
+                [$data[1]],
+            )->willReturnOnConsecutiveCalls(
+                $groupKey,
+                null,
+            );
 
         $groupedConditionalAvailabilityTransfers = $this->conditionalAvailabilityBulkApiMapper
             ->mapApiDataTransferToGroupedConditionalAvailabilityTransfers(
                 $this->apiDataTransferMock,
             );
 
-        static::assertArrayHasKey($data[0]['warehouse_group'], $groupedConditionalAvailabilityTransfers);
-        static::assertArrayHasKey(
-            $data[0]['sku'],
-            $groupedConditionalAvailabilityTransfers[$data[0]['warehouse_group']],
+        static::assertEquals([$groupKey], array_keys($groupedConditionalAvailabilityTransfers));
+        static::assertEquals(
+            [$data[0]['sku']],
+            array_keys($groupedConditionalAvailabilityTransfers[$groupKey]),
         );
         static::assertInstanceOf(
             ConditionalAvailabilityTransfer::class,
-            $groupedConditionalAvailabilityTransfers[$data[0]['warehouse_group']][$data[0]['sku']],
+            $groupedConditionalAvailabilityTransfers[$groupKey][$data[0]['sku']],
         );
     }
 }


### PR DESCRIPTION
- generate group key by api data
- use generated group key instead of warehouse group (this allows to use multiple values from api data)
- ...