### PR TITLE
♻️ use ConditionalAvailabilityEvents::ENTITY_FOI_CONDITIONAL_AVAILABILITY_PERIOD_CREATE as event name for the listener

### DIFF
--- a/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Listener/ConditionalAvailabilityProductPageSearchPublishListener.php
+++ b/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Listener/ConditionalAvailabilityProductPageSearchPublishListener.php
@@ -3,14 +3,14 @@
 namespace FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener;
 
 use Generated\Shared\Transfer\ConditionalAvailabilityCriteriaFilterTransfer;
+use Orm\Zed\ConditionalAvailability\Persistence\Map\FoiConditionalAvailabilityPeriodTableMap;
 use Spryker\Zed\Event\Dependency\Plugin\EventBulkHandlerInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 
 /**
  * @method \FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\ConditionalAvailabilityProductPageSearchCommunicationFactory getFactory()
- * @method \FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Business\ConditionalAvailabilityProductPageSearchFacadeInterface getFacade()
  */
-class ConditionalAvailabilityProductConcretePageSearchPublishListener extends AbstractPlugin implements EventBulkHandlerInterface
+class ConditionalAvailabilityProductPageSearchPublishListener extends AbstractPlugin implements EventBulkHandlerInterface
 {
     /**
      * {@inheritDoc}
@@ -27,7 +27,10 @@ class ConditionalAvailabilityProductConcretePageSearchPublishListener extends Ab
     {
         $conditionalAvailabilityIds = $this->getFactory()
             ->getEventBehaviorFacade()
-            ->getEventTransferIds($eventEntityTransfers);
+            ->getEventTransferForeignKeys(
+                $eventEntityTransfers,
+                FoiConditionalAvailabilityPeriodTableMap::COL_FK_CONDITIONAL_AVAILABILITY,
+            );
 
         $conditionalAvailabilityCriteriaFilterTransfer = (new ConditionalAvailabilityCriteriaFilterTransfer())
             ->setIds($conditionalAvailabilityIds);

--- a/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Subscriber/ConditionalAvailabilityProductPageSearchEventSubscriber.php
+++ b/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Subscriber/ConditionalAvailabilityProductPageSearchEventSubscriber.php
@@ -3,7 +3,7 @@
 namespace FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Subscriber;
 
 use FondOfImpala\Zed\ConditionalAvailability\Dependency\ConditionalAvailabilityEvents;
-use FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener\ConditionalAvailabilityProductConcretePageSearchPublishListener;
+use FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener\ConditionalAvailabilityProductPageSearchPublishListener;
 use Spryker\Zed\Event\Dependency\EventCollectionInterface;
 use Spryker\Zed\Event\Dependency\Plugin\EventSubscriberInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
@@ -20,8 +20,8 @@ class ConditionalAvailabilityProductPageSearchEventSubscriber extends AbstractPl
     public function getSubscribedEvents(EventCollectionInterface $eventCollection): EventCollectionInterface
     {
         $eventCollection->addListenerQueued(
-            ConditionalAvailabilityEvents::ENTITY_FOI_CONDITIONAL_AVAILABILITY_CREATE,
-            new ConditionalAvailabilityProductConcretePageSearchPublishListener(),
+            ConditionalAvailabilityEvents::ENTITY_FOI_CONDITIONAL_AVAILABILITY_PERIOD_CREATE,
+            new ConditionalAvailabilityProductPageSearchPublishListener(),
         );
 
         return $eventCollection;

--- a/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Dependency/Facade/ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeBridge.php
+++ b/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Dependency/Facade/ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeBridge.php
@@ -19,11 +19,12 @@ class ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeBridge implem
 
     /**
      * @param array<\Generated\Shared\Transfer\EventEntityTransfer> $eventTransfers
+     * @param string $foreignKeyColumnName
      *
-     * @return array<int>
+     * @return array
      */
-    public function getEventTransferIds(array $eventTransfers): array
+    public function getEventTransferForeignKeys(array $eventTransfers, string $foreignKeyColumnName): array
     {
-        return $this->eventBehaviorFacade->getEventTransferIds($eventTransfers);
+        return $this->eventBehaviorFacade->getEventTransferForeignKeys($eventTransfers, $foreignKeyColumnName);
     }
 }

--- a/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Dependency/Facade/ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeInterface.php
+++ b/bundles/conditional-availability-product-page-search/src/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Dependency/Facade/ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeInterface.php
@@ -6,8 +6,9 @@ interface ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeInterface
 {
     /**
      * @param array<\Generated\Shared\Transfer\EventEntityTransfer> $eventTransfers
+     * @param string $foreignKeyColumnName
      *
-     * @return array<int>
+     * @return array
      */
-    public function getEventTransferIds(array $eventTransfers): array;
+    public function getEventTransferForeignKeys(array $eventTransfers, string $foreignKeyColumnName): array;
 }

--- a/bundles/conditional-availability-product-page-search/tests/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Listener/ConditionalAvailabilityProductPageSearchPublishListenerTest.php
+++ b/bundles/conditional-availability-product-page-search/tests/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Listener/ConditionalAvailabilityProductPageSearchPublishListenerTest.php
@@ -14,7 +14,7 @@ use Generated\Shared\Transfer\ConditionalAvailabilityTransfer;
 use Generated\Shared\Transfer\EventEntityTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
 
-class ConditionalAvailabilityProductConcretePageSearchPublishListenerTest extends Unit
+class ConditionalAvailabilityProductPageSearchPublishListenerTest extends Unit
 {
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Dependency\Facade\ConditionalAvailabilityProductPageSearchToConditionalAvailabilityFacadeInterface
@@ -47,9 +47,9 @@ class ConditionalAvailabilityProductConcretePageSearchPublishListenerTest extend
     protected MockObject|EventEntityTransfer $eventEntityTransferMock;
 
     /**
-     * @var \FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener\ConditionalAvailabilityProductConcretePageSearchPublishListener
+     * @var \FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener\ConditionalAvailabilityProductPageSearchPublishListener
      */
-    protected ConditionalAvailabilityProductConcretePageSearchPublishListener $listener;
+    protected ConditionalAvailabilityProductPageSearchPublishListener $listener;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Dependency\Facade\ConditionalAvailabilityProductPageSearchToProductPageSearchFacadeInterface
@@ -100,7 +100,7 @@ class ConditionalAvailabilityProductConcretePageSearchPublishListenerTest extend
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->listener = new ConditionalAvailabilityProductConcretePageSearchPublishListener();
+        $this->listener = new ConditionalAvailabilityProductPageSearchPublishListener();
         $this->listener->setFactory($this->factoryMock);
     }
 
@@ -119,7 +119,7 @@ class ConditionalAvailabilityProductConcretePageSearchPublishListenerTest extend
             ->willReturn($this->eventBehaviorFacadeMock);
 
         $this->eventBehaviorFacadeMock->expects(static::atLeastOnce())
-            ->method('getEventTransferIds')
+            ->method('getEventTransferForeignKeys')
             ->with($eventEntityTransfers)
             ->willReturn($conditionalAvailabilityIds);
 

--- a/bundles/conditional-availability-product-page-search/tests/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Subscriber/ConditionalAvailabilitySearchEventSubscriberTest.php
+++ b/bundles/conditional-availability-product-page-search/tests/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Communication/Plugin/Event/Subscriber/ConditionalAvailabilitySearchEventSubscriberTest.php
@@ -5,7 +5,7 @@ namespace FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communicatio
 use Codeception\Test\Unit;
 use Exception;
 use FondOfImpala\Zed\ConditionalAvailability\Dependency\ConditionalAvailabilityEvents;
-use FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener\ConditionalAvailabilityProductConcretePageSearchPublishListener;
+use FondOfImpala\Zed\ConditionalAvailabilityProductPageSearch\Communication\Plugin\Event\Listener\ConditionalAvailabilityProductPageSearchPublishListener;
 use PHPUnit\Framework\MockObject\MockObject;
 use Spryker\Zed\Event\Dependency\EventCollectionInterface;
 use Spryker\Zed\Event\Dependency\Plugin\EventBaseHandlerInterface;
@@ -45,8 +45,8 @@ class ConditionalAvailabilitySearchEventSubscriberTest extends Unit
             ->expects(static::exactly(1))
             ->method('addListenerQueued')
             ->willReturnCallback(static function (string $eventName, EventBaseHandlerInterface $eventHandler) {
-                if ($eventName === ConditionalAvailabilityEvents::ENTITY_FOI_CONDITIONAL_AVAILABILITY_CREATE) {
-                    static::assertInstanceOf(ConditionalAvailabilityProductConcretePageSearchPublishListener::class, $eventHandler);
+                if ($eventName === ConditionalAvailabilityEvents::ENTITY_FOI_CONDITIONAL_AVAILABILITY_PERIOD_CREATE) {
+                    static::assertInstanceOf(ConditionalAvailabilityProductPageSearchPublishListener::class, $eventHandler);
 
                     return;
                 }

--- a/bundles/conditional-availability-product-page-search/tests/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Dependency/Facade/ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeBridgeTest.php
+++ b/bundles/conditional-availability-product-page-search/tests/FondOfImpala/Zed/ConditionalAvailabilityProductPageSearch/Dependency/Facade/ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeBridgeTest.php
@@ -35,14 +35,15 @@ class ConditionalAvailabilityProductPageSearchToEventBehaviorFacadeBridgeTest ex
     /**
      * @return void
      */
-    public function testGetEventTransferIds(): void
+    public function testGetEventTransferForeignKeys(): void
     {
         $eventTransfers = [];
+        $foreignKeyColumnName = 'foreignKeyColumnName';
         $this->eventBehaviorFacadeMock->expects(static::atLeastOnce())
-            ->method('getEventTransferIds')
-            ->with($eventTransfers)
+            ->method('getEventTransferForeignKeys')
+            ->with($eventTransfers, $foreignKeyColumnName)
             ->willReturn([]);
 
-        static::assertIsArray($this->bridge->getEventTransferIds($eventTransfers));
+        static::assertIsArray($this->bridge->getEventTransferForeignKeys($eventTransfers, $foreignKeyColumnName));
     }
 }


### PR DESCRIPTION
- change event name for the listener because it is triggered always on create and update
- update EventBehavior Dependency Facade code
- update Unit Test