### PR TITLE
🧹 product-product-list-connector product list wrapper

### DIFF
--- a/bundles/product-product-list-connector/src/FondOfImpala/Shared/ProductProductListConnector/Transfer/product_product_list_connector.transfer.xml
+++ b/bundles/product-product-list-connector/src/FondOfImpala/Shared/ProductProductListConnector/Transfer/product_product_list_connector.transfer.xml
@@ -12,13 +12,11 @@
         <property name="productListProductConcreteRelation" type="ProductListProductConcreteRelation"/>
     </transfer>
 
-    <transfer name="ProductAbstract">
-        <property name="idProductAbstract" type="int" />
+    <transfer name="ProductListCollection">
         <property name="productLists" type="ProductList[]" singular="productList" />
-        <property name="productListIds" type="int[]" singular="productListId" />
     </transfer>
 
     <transfer name="ProductConcrete">
-        <property name="productLists" type="ProductList[]" singular="productList" />
+        <property name="productListCollection" type="ProductListCollection" />
     </transfer>
 </transfers>

--- a/bundles/product-product-list-connector/src/FondOfImpala/Zed/ProductProductListConnector/Business/Manager/ProductListManager.php
+++ b/bundles/product-product-list-connector/src/FondOfImpala/Zed/ProductProductListConnector/Business/Manager/ProductListManager.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\ProductProductListConnector\Business\Manager;
 use FondOfImpala\Zed\ProductProductListConnector\Persistence\ProductProductListConnectorEntityManagerInterface;
 use FondOfImpala\Zed\ProductProductListConnector\Persistence\ProductProductListConnectorRepositoryInterface;
 use Generated\Shared\Transfer\ProductConcreteTransfer;
+use Generated\Shared\Transfer\ProductListCollectionTransfer;
 
 class ProductListManager implements ProductListManagerInterface
 {
@@ -55,16 +56,23 @@ class ProductListManager implements ProductListManagerInterface
      */
     protected function manageProductToProductListRelations(ProductConcreteTransfer $productConcreteTransfer): void
     {
-        $productLists = $this->entityManager->findOrCreateProductLists($productConcreteTransfer->getProductLists());
+        $productListCollection = $productConcreteTransfer->getProductListCollection();
+
+        if ($productListCollection === null){
+            return;
+        }
+
+        $productLists = $this->entityManager->findOrCreateProductLists($productListCollection->getProductLists());
         $productListsAlreadyIn = $this->repository->findProductListsByProductRelation($productConcreteTransfer->getIdProductConcrete())->getArrayCopy();
 
         $createRelation = [];
+        $productListCollection = new ProductListCollectionTransfer();
 
         foreach ($productLists->getArrayCopy() as $productListTransfer) {
             $key = $productListTransfer->getKey();
             if (array_key_exists($key, $productListsAlreadyIn)) {
                 unset($productListsAlreadyIn[$key]);
-
+                $productListCollection->addProductList($productListTransfer);
                 continue;
             }
             $createRelation[$key] = $productListTransfer;
@@ -72,12 +80,13 @@ class ProductListManager implements ProductListManagerInterface
 
         foreach ($createRelation as $productList) {
             $this->entityManager->createProductToProductListRelation($productConcreteTransfer, $productList);
+            $productListCollection->addProductList($productList);
         }
 
         foreach ($productListsAlreadyIn as $productList) {
             $this->entityManager->deleteProductToProductListRelation($productConcreteTransfer, $productList);
         }
 
-        $productConcreteTransfer->setProductLists($productLists);
+        $productConcreteTransfer->setProductListCollection($productListCollection);
     }
 }

--- a/bundles/product-product-list-connector/src/FondOfImpala/Zed/ProductProductListConnector/Business/Manager/ProductListManager.php
+++ b/bundles/product-product-list-connector/src/FondOfImpala/Zed/ProductProductListConnector/Business/Manager/ProductListManager.php
@@ -58,7 +58,7 @@ class ProductListManager implements ProductListManagerInterface
     {
         $productListCollection = $productConcreteTransfer->getProductListCollection();
 
-        if ($productListCollection === null){
+        if ($productListCollection === null) {
             return;
         }
 
@@ -73,6 +73,7 @@ class ProductListManager implements ProductListManagerInterface
             if (array_key_exists($key, $productListsAlreadyIn)) {
                 unset($productListsAlreadyIn[$key]);
                 $productListCollection->addProductList($productListTransfer);
+
                 continue;
             }
             $createRelation[$key] = $productListTransfer;

--- a/bundles/product-product-list-connector/tests/FondOfImpala/Zed/ProductProductListConnector/Business/Manager/ProductListManagerTest.php
+++ b/bundles/product-product-list-connector/tests/FondOfImpala/Zed/ProductProductListConnector/Business/Manager/ProductListManagerTest.php
@@ -7,6 +7,7 @@ use Codeception\Test\Unit;
 use FondOfImpala\Zed\ProductProductListConnector\Persistence\ProductProductListConnectorEntityManagerInterface;
 use FondOfImpala\Zed\ProductProductListConnector\Persistence\ProductProductListConnectorRepositoryInterface;
 use Generated\Shared\Transfer\ProductConcreteTransfer;
+use Generated\Shared\Transfer\ProductListCollectionTransfer;
 use Generated\Shared\Transfer\ProductListTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -19,6 +20,8 @@ class ProductListManagerTest extends Unit
     protected ProductConcreteTransfer|MockObject $productConcreteTransferMock;
 
     protected ProductListTransfer|MockObject $productListTransferMock;
+
+    protected ProductListCollectionTransfer|MockObject $productListCollectionTransferMock;
 
     protected ProductListTransfer|MockObject $productListTransfer2Mock;
 
@@ -57,7 +60,25 @@ class ProductListManagerTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
+        $this->productListCollectionTransferMock = $this->getMockBuilder(ProductListCollectionTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $this->manager = new ProductListManager($this->repositoryMock, $this->entityManagerMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAddProductToProductListsEarlyExit(): void
+    {
+        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductListCollection')->willReturn(null);
+        $this->entityManagerMock->expects(static::never())->method('findOrCreateProductLists');
+        $this->repositoryMock->expects(static::never())->method('findProductListsByProductRelation');
+        $this->entityManagerMock->expects(static::never())->method('createProductToProductListRelation');
+        $this->entityManagerMock->expects(static::never())->method('deleteProductToProductListRelation');
+
+        $this->manager->addProductToProductLists($this->productConcreteTransferMock);
     }
 
     /**
@@ -70,7 +91,8 @@ class ProductListManagerTest extends Unit
         $productListsAlreadyExists = new ArrayObject();
         $idProductConcrete = 1;
 
-        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productListCollectionTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductListCollection')->willReturn($this->productListCollectionTransferMock);
         $this->entityManagerMock->expects(static::atLeastOnce())->method('findOrCreateProductLists')->willReturn($productListsCreated);
         $this->repositoryMock->expects(static::atLeastOnce())->method('findProductListsByProductRelation')->willReturn($productListsAlreadyExists);
         $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getIdProductConcrete')->willReturn($idProductConcrete);
@@ -91,7 +113,8 @@ class ProductListManagerTest extends Unit
         $idProductConcrete = 1;
 
         $this->productListTransferMock->expects(static::atLeastOnce())->method('getKey')->willReturn($productListKey);
-        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productListCollectionTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductListCollection')->willReturn($this->productListCollectionTransferMock);
         $this->entityManagerMock->expects(static::atLeastOnce())->method('findOrCreateProductLists')->willReturn($productLists);
         $this->repositoryMock->expects(static::atLeastOnce())->method('findProductListsByProductRelation')->willReturn($productListsAlreadyExists);
         $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getIdProductConcrete')->willReturn($idProductConcrete);
@@ -113,7 +136,8 @@ class ProductListManagerTest extends Unit
         $idProductConcrete = 1;
 
         $this->productListTransferMock->expects(static::atLeastOnce())->method('getKey')->willReturn($productListKey);
-        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productListCollectionTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductListCollection')->willReturn($this->productListCollectionTransferMock);
         $this->entityManagerMock->expects(static::atLeastOnce())->method('findOrCreateProductLists')->willReturn($productLists);
         $this->repositoryMock->expects(static::atLeastOnce())->method('findProductListsByProductRelation')->willReturn($productListsAlreadyExists);
         $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getIdProductConcrete')->willReturn($idProductConcrete);
@@ -147,7 +171,8 @@ class ProductListManagerTest extends Unit
 
         $this->productListTransferMock->expects(static::atLeastOnce())->method('getKey')->willReturn($productListKey);
         $this->productListTransfer3Mock->expects(static::atLeastOnce())->method('getKey')->willReturn($productListKey3);
-        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productListCollectionTransferMock->expects(static::atLeastOnce())->method('getProductLists')->willReturn($productLists);
+        $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getProductListCollection')->willReturn($this->productListCollectionTransferMock);
         $this->entityManagerMock->expects(static::atLeastOnce())->method('findOrCreateProductLists')->willReturn($productLists);
         $this->repositoryMock->expects(static::atLeastOnce())->method('findProductListsByProductRelation')->willReturn($productListsAlreadyExists);
         $this->productConcreteTransferMock->expects(static::atLeastOnce())->method('getIdProductConcrete')->willReturn($idProductConcrete);


### PR DESCRIPTION
Added collection wrapper for handling null and empty array data to prevent unexpected deleting of product list relations