### PR TITLE
🐛 fix company role deletion 

### DIFF
--- a/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Business/Model/CompanyTypeRoleWriter.php
+++ b/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Business/Model/CompanyTypeRoleWriter.php
@@ -167,7 +167,7 @@ class CompanyTypeRoleWriter implements CompanyTypeRoleWriterInterface
             $companyRoleTransfer = (new CompanyRoleTransfer())
                 ->setIdCompanyRole($roleTransfer->getIdCompanyRole());
 
-            return $this->companyRoleFacade->delete($companyRoleTransfer);
+            return $this->companyTypeRoleFacade->deleteCompanyRoleAndCompanyUserByCompanyRole($companyRoleTransfer);
         }
 
         return null;

--- a/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeBridge.php
+++ b/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeBridge.php
@@ -3,6 +3,7 @@
 namespace FondOfImpala\Zed\CompanyTypeConverter\Dependency\Facade;
 
 use FondOfImpala\Zed\CompanyTypeRole\Business\CompanyTypeRoleFacadeInterface;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleTransfer;
 use Generated\Shared\Transfer\CompanyTypeTransfer;
 
@@ -33,5 +34,14 @@ class CompanyTypeConverterToCompanyTypeRoleFacadeBridge implements CompanyTypeCo
     ): array {
         return $this->companyTypeRoleFacade
             ->getPermissionKeysByCompanyTypeAndCompanyRole($companyTypeTransfer, $companyRoleTransfer);
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
+     */
+    public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer
+    {
+        return $this->companyTypeRoleFacade->deleteCompanyRoleAndCompanyUserByCompanyRole($companyRoleTransfer);
     }
 }

--- a/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeBridge.php
+++ b/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeBridge.php
@@ -38,6 +38,7 @@ class CompanyTypeConverterToCompanyTypeRoleFacadeBridge implements CompanyTypeCo
 
     /**
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     *
      * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
      */
     public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer

--- a/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeInterface.php
+++ b/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeInterface.php
@@ -21,6 +21,7 @@ interface CompanyTypeConverterToCompanyTypeRoleFacadeInterface
 
     /**
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     *
      * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
      */
     public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer;

--- a/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeInterface.php
+++ b/bundles/company-type-converter/src/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeInterface.php
@@ -2,6 +2,7 @@
 
 namespace FondOfImpala\Zed\CompanyTypeConverter\Dependency\Facade;
 
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleTransfer;
 use Generated\Shared\Transfer\CompanyTypeTransfer;
 
@@ -17,4 +18,10 @@ interface CompanyTypeConverterToCompanyTypeRoleFacadeInterface
         CompanyTypeTransfer $companyTypeTransfer,
         CompanyRoleTransfer $companyRoleTransfer
     ): array;
+
+    /**
+     * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
+     */
+    public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer;
 }

--- a/bundles/company-type-converter/tests/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeBridgeTest.php
+++ b/bundles/company-type-converter/tests/FondOfImpala/Zed/CompanyTypeConverter/Dependency/Facade/CompanyTypeConverterToCompanyTypeRoleFacadeBridgeTest.php
@@ -4,8 +4,10 @@ namespace FondOfImpala\Zed\CompanyTypeConverter\Dependency\Facade;
 
 use Codeception\Test\Unit;
 use FondOfImpala\Zed\CompanyTypeRole\Business\CompanyTypeRoleFacadeInterface;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleTransfer;
 use Generated\Shared\Transfer\CompanyTypeTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class CompanyTypeConverterToCompanyTypeRoleFacadeBridgeTest extends Unit
 {
@@ -19,10 +21,9 @@ class CompanyTypeConverterToCompanyTypeRoleFacadeBridgeTest extends Unit
      */
     protected $companyTypeTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\CompanyRoleTransfer
-     */
-    protected $companyRoleTransferMock;
+    protected CompanyRoleResponseTransfer|MockObject $companyRoleResponseTransferMock;
+
+    protected CompanyRoleTransfer|MockObject $companyRoleTransferMock;
 
     /**
      * @var \FondOfImpala\Zed\CompanyTypeConverter\Dependency\Facade\CompanyTypeConverterToCompanyTypeRoleFacadeBridge
@@ -45,6 +46,10 @@ class CompanyTypeConverterToCompanyTypeRoleFacadeBridgeTest extends Unit
             ->getMock();
 
         $this->companyRoleTransferMock = $this->getMockBuilder(CompanyRoleTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleResponseTransferMock = $this->getMockBuilder(CompanyRoleResponseTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -77,5 +82,21 @@ class CompanyTypeConverterToCompanyTypeRoleFacadeBridgeTest extends Unit
         $this->assertNotEmpty($permissionKeysResult);
         $this->assertEquals($permissionKeys, $permissionKeysResult);
         $this->assertTrue(is_array($permissionKeysResult));
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteCompanyRoleAndCompanyUserByCompanyRole(): void
+    {
+        $this->companyTypeRoleFacadeMock->expects($this->atLeastOnce())
+            ->method('deleteCompanyRoleAndCompanyUserByCompanyRole')
+            ->with($this->companyRoleTransferMock)
+            ->willReturn($this->companyRoleResponseTransferMock);
+
+        $this->companyTypeConverterToCompanyTypeRoleFacadeBridge
+            ->deleteCompanyRoleAndCompanyUserByCompanyRole(
+                $this->companyRoleTransferMock,
+            );
     }
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleBusinessFactory.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleBusinessFactory.php
@@ -12,6 +12,8 @@ use FondOfImpala\Zed\CompanyTypeRole\Business\Mapper\PermissionKeyMapper;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Mapper\PermissionKeyMapperInterface;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleAssigner;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleAssignerInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleDeleter;
+use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleDeleterInterface;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\PermissionReader;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\PermissionReaderInterface;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Reader\AssignableCompanyRoleReader;
@@ -139,6 +141,18 @@ class CompanyTypeRoleBusinessFactory extends AbstractBusinessFactory
             $this->createCompanyUserReader(),
             $this->getCompanyRoleFacade(),
             $this->getPermissionFacade(),
+        );
+    }
+
+    /**
+     * @return \FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleDeleterInterface
+     */
+    public function createCompanyRoleDeleter(): CompanyRoleDeleterInterface
+    {
+        return new CompanyRoleDeleter(
+            $this->getCompanyUserFacade(),
+            $this->getCompanyRoleFacade(),
+            $this->getRepository()
         );
     }
 

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleBusinessFactory.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleBusinessFactory.php
@@ -152,7 +152,7 @@ class CompanyTypeRoleBusinessFactory extends AbstractBusinessFactory
         return new CompanyRoleDeleter(
             $this->getCompanyUserFacade(),
             $this->getCompanyRoleFacade(),
-            $this->getRepository()
+            $this->getRepository(),
         );
     }
 

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacade.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacade.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\CompanyTypeRole\Business;
 use Generated\Shared\Transfer\AssignableCompanyRoleCriteriaFilterTransfer;
 use Generated\Shared\Transfer\CompanyResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleCollectionTransfer;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleTransfer;
 use Generated\Shared\Transfer\CompanyTypeTransfer;
 use Generated\Shared\Transfer\EventEntityTransfer;
@@ -19,15 +20,16 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
-     * @api
-     *
      * @param \Generated\Shared\Transfer\CompanyResponseTransfer $companyResponseTransfer
      *
      * @return \Generated\Shared\Transfer\CompanyResponseTransfer
+     * @api
+     *
      */
     public function assignPredefinedCompanyRolesToNewCompany(
         CompanyResponseTransfer $companyResponseTransfer
-    ): CompanyResponseTransfer {
+    ): CompanyResponseTransfer
+    {
         return $this->getFactory()->createCompanyRoleAssigner()
             ->assignPredefinedCompanyRolesToNewCompany($companyResponseTransfer);
     }
@@ -35,11 +37,11 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
-     * @api
-     *
      * @param \Generated\Shared\Transfer\EventEntityTransfer $transfer
      *
      * @return bool
+     * @api
+     *
      */
     public function validateCompanyTypeRoleForExport(EventEntityTransfer $transfer): bool
     {
@@ -51,17 +53,18 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
-     * @api
-     *
      * @param \Generated\Shared\Transfer\CompanyTypeTransfer $companyTypeTransfer
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
      *
      * @return array<string>
+     * @api
+     *
      */
     public function getPermissionKeysByCompanyTypeAndCompanyRole(
         CompanyTypeTransfer $companyTypeTransfer,
         CompanyRoleTransfer $companyRoleTransfer
-    ): array {
+    ): array
+    {
         return $this->getFactory()
             ->createPermissionReader()
             ->getCompanyTypeRolePermissionKeys($companyTypeTransfer, $companyRoleTransfer);
@@ -70,9 +73,9 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
+     * @return void
      * @api
      *
-     * @return void
      */
     public function syncPermissions(): void
     {
@@ -82,9 +85,9 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
+     * @return void
      * @api
      *
-     * @return void
      */
     public function syncCompanyRoles(): void
     {
@@ -94,17 +97,29 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
-     * @api
-     *
      * @param \Generated\Shared\Transfer\AssignableCompanyRoleCriteriaFilterTransfer $assignableCompanyRoleCriteriaFilterTransfer
      *
      * @return \Generated\Shared\Transfer\CompanyRoleCollectionTransfer
+     * @api
+     *
      */
     public function getAssignableCompanyRoles(
         AssignableCompanyRoleCriteriaFilterTransfer $assignableCompanyRoleCriteriaFilterTransfer
-    ): CompanyRoleCollectionTransfer {
+    ): CompanyRoleCollectionTransfer
+    {
         return $this->getFactory()->createAssignableCompanyRoleReader()->getByAssignableCompanyRoleCriteriaFilter(
             $assignableCompanyRoleCriteriaFilterTransfer,
+        );
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
+     */
+    public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer
+    {
+        return $this->getFactory()->createCompanyRoleDeleter()->deleteCompanyRoleAndCompanyUserByCompanyRole(
+            $companyRoleTransfer,
         );
     }
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacade.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacade.php
@@ -20,16 +20,15 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\CompanyResponseTransfer $companyResponseTransfer
      *
      * @return \Generated\Shared\Transfer\CompanyResponseTransfer
-     * @api
-     *
      */
     public function assignPredefinedCompanyRolesToNewCompany(
         CompanyResponseTransfer $companyResponseTransfer
-    ): CompanyResponseTransfer
-    {
+    ): CompanyResponseTransfer {
         return $this->getFactory()->createCompanyRoleAssigner()
             ->assignPredefinedCompanyRolesToNewCompany($companyResponseTransfer);
     }
@@ -37,11 +36,11 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\EventEntityTransfer $transfer
      *
      * @return bool
-     * @api
-     *
      */
     public function validateCompanyTypeRoleForExport(EventEntityTransfer $transfer): bool
     {
@@ -53,18 +52,17 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\CompanyTypeTransfer $companyTypeTransfer
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
      *
      * @return array<string>
-     * @api
-     *
      */
     public function getPermissionKeysByCompanyTypeAndCompanyRole(
         CompanyTypeTransfer $companyTypeTransfer,
         CompanyRoleTransfer $companyRoleTransfer
-    ): array
-    {
+    ): array {
         return $this->getFactory()
             ->createPermissionReader()
             ->getCompanyTypeRolePermissionKeys($companyTypeTransfer, $companyRoleTransfer);
@@ -73,9 +71,9 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
-     * @return void
      * @api
      *
+     * @return void
      */
     public function syncPermissions(): void
     {
@@ -85,9 +83,9 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
-     * @return void
      * @api
      *
+     * @return void
      */
     public function syncCompanyRoles(): void
     {
@@ -97,16 +95,15 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
     /**
      * {@inheritDoc}
      *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\AssignableCompanyRoleCriteriaFilterTransfer $assignableCompanyRoleCriteriaFilterTransfer
      *
      * @return \Generated\Shared\Transfer\CompanyRoleCollectionTransfer
-     * @api
-     *
      */
     public function getAssignableCompanyRoles(
         AssignableCompanyRoleCriteriaFilterTransfer $assignableCompanyRoleCriteriaFilterTransfer
-    ): CompanyRoleCollectionTransfer
-    {
+    ): CompanyRoleCollectionTransfer {
         return $this->getFactory()->createAssignableCompanyRoleReader()->getByAssignableCompanyRoleCriteriaFilter(
             $assignableCompanyRoleCriteriaFilterTransfer,
         );
@@ -114,6 +111,7 @@ class CompanyTypeRoleFacade extends AbstractFacade implements CompanyTypeRoleFac
 
     /**
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     *
      * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
      */
     public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacadeInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacadeInterface.php
@@ -93,6 +93,7 @@ interface CompanyTypeRoleFacadeInterface
 
     /**
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     *
      * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
      */
     public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer;

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacadeInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacadeInterface.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\CompanyTypeRole\Business;
 use Generated\Shared\Transfer\AssignableCompanyRoleCriteriaFilterTransfer;
 use Generated\Shared\Transfer\CompanyResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleCollectionTransfer;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleTransfer;
 use Generated\Shared\Transfer\CompanyTypeTransfer;
 use Generated\Shared\Transfer\EventEntityTransfer;
@@ -89,4 +90,10 @@ interface CompanyTypeRoleFacadeInterface
     public function getAssignableCompanyRoles(
         AssignableCompanyRoleCriteriaFilterTransfer $assignableCompanyRoleCriteriaFilterTransfer
     ): CompanyRoleCollectionTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
+     */
+    public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer;
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleter.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleter.php
@@ -25,8 +25,7 @@ class CompanyRoleDeleter implements CompanyRoleDeleterInterface
         CompanyTypeRoleToCompanyUserFacadeInterface $companyUserFacade,
         CompanyTypeRoleToCompanyRoleFacadeInterface $companyRoleFacade,
         CompanyTypeRoleRepositoryInterface $repository
-    )
-    {
+    ) {
         $this->companyUserFacade = $companyUserFacade;
         $this->companyRoleFacade = $companyRoleFacade;
         $this->repository = $repository;
@@ -34,13 +33,14 @@ class CompanyRoleDeleter implements CompanyRoleDeleterInterface
 
     /**
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     *
      * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
      */
     public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer
     {
         $companyUserCollection = $this->repository->findCompanyUserIdsByCompanyRoleId($companyRoleTransfer->getIdCompanyRole());
 
-        foreach ($companyUserCollection->getCompanyUsers() as $companyUser){
+        foreach ($companyUserCollection->getCompanyUsers() as $companyUser) {
             $this->companyUserFacade->deleteCompanyUser($companyUser);
         }
 

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleter.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleter.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace FondOfImpala\Zed\CompanyTypeRole\Business\Model;
+
+use FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade\CompanyTypeRoleToCompanyRoleFacadeInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade\CompanyTypeRoleToCompanyUserFacadeInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Persistence\CompanyTypeRoleRepositoryInterface;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
+use Generated\Shared\Transfer\CompanyRoleTransfer;
+
+class CompanyRoleDeleter implements CompanyRoleDeleterInterface
+{
+    protected CompanyTypeRoleToCompanyUserFacadeInterface $companyUserFacade;
+
+    protected CompanyTypeRoleToCompanyRoleFacadeInterface $companyRoleFacade;
+
+    protected CompanyTypeRoleRepositoryInterface $repository;
+
+    /**
+     * @param \FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade\CompanyTypeRoleToCompanyUserFacadeInterface $companyUserFacade
+     * @param \FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade\CompanyTypeRoleToCompanyRoleFacadeInterface $companyRoleFacade
+     * @param \FondOfImpala\Zed\CompanyTypeRole\Persistence\CompanyTypeRoleRepositoryInterface $repository
+     */
+    public function __construct(
+        CompanyTypeRoleToCompanyUserFacadeInterface $companyUserFacade,
+        CompanyTypeRoleToCompanyRoleFacadeInterface $companyRoleFacade,
+        CompanyTypeRoleRepositoryInterface $repository
+    )
+    {
+        $this->companyUserFacade = $companyUserFacade;
+        $this->companyRoleFacade = $companyRoleFacade;
+        $this->repository = $repository;
+    }
+
+    /**
+     * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
+     */
+    public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer
+    {
+        $companyUserCollection = $this->repository->findCompanyUserIdsByCompanyRoleId($companyRoleTransfer->getIdCompanyRole());
+
+        foreach ($companyUserCollection->getCompanyUsers() as $companyUser){
+            $this->companyUserFacade->deleteCompanyUser($companyUser);
+        }
+
+        return $this->companyRoleFacade->delete($companyRoleTransfer);
+    }
+}

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleterInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleterInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FondOfImpala\Zed\CompanyTypeRole\Business\Model;
+
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
+use Generated\Shared\Transfer\CompanyRoleTransfer;
+
+interface CompanyRoleDeleterInterface
+{
+    /**
+     * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
+     */
+    public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer;
+}

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleterInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleterInterface.php
@@ -9,6 +9,7 @@ interface CompanyRoleDeleterInterface
 {
     /**
      * @param \Generated\Shared\Transfer\CompanyRoleTransfer $companyRoleTransfer
+     *
      * @return \Generated\Shared\Transfer\CompanyRoleResponseTransfer
      */
     public function deleteCompanyRoleAndCompanyUserByCompanyRole(CompanyRoleTransfer $companyRoleTransfer): CompanyRoleResponseTransfer;

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeBridge.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeBridge.php
@@ -4,6 +4,7 @@ namespace FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade;
 
 use Generated\Shared\Transfer\CompanyUserCollectionTransfer;
 use Generated\Shared\Transfer\CompanyUserCriteriaFilterTransfer;
+use Generated\Shared\Transfer\CompanyUserResponseTransfer;
 use Generated\Shared\Transfer\CompanyUserTransfer;
 use Spryker\Zed\CompanyUser\Business\CompanyUserFacadeInterface;
 
@@ -39,7 +40,24 @@ class CompanyTypeRoleToCompanyUserFacadeBridge implements CompanyTypeRoleToCompa
      */
     public function getCompanyUserCollection(
         CompanyUserCriteriaFilterTransfer $companyUserCriteriaFilterTransfer
-    ): CompanyUserCollectionTransfer {
+    ): CompanyUserCollectionTransfer
+    {
         return $this->companyUserFacade->getCompanyUserCollection($companyUserCriteriaFilterTransfer);
+    }
+
+    /**
+     * Specification:
+     * - Executes CompanyUserPreDeletePluginInterface plugins before delete company user.
+     * - Deletes a company user.
+     *
+     * @param \Generated\Shared\Transfer\CompanyUserTransfer $companyUserTransfer
+     *
+     * @return \Generated\Shared\Transfer\CompanyUserResponseTransfer
+     * @api
+     *
+     */
+    public function deleteCompanyUser(CompanyUserTransfer $companyUserTransfer): CompanyUserResponseTransfer
+    {
+        return $this->companyUserFacade->deleteCompanyUser($companyUserTransfer);
     }
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeBridge.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeBridge.php
@@ -40,8 +40,7 @@ class CompanyTypeRoleToCompanyUserFacadeBridge implements CompanyTypeRoleToCompa
      */
     public function getCompanyUserCollection(
         CompanyUserCriteriaFilterTransfer $companyUserCriteriaFilterTransfer
-    ): CompanyUserCollectionTransfer
-    {
+    ): CompanyUserCollectionTransfer {
         return $this->companyUserFacade->getCompanyUserCollection($companyUserCriteriaFilterTransfer);
     }
 
@@ -50,11 +49,11 @@ class CompanyTypeRoleToCompanyUserFacadeBridge implements CompanyTypeRoleToCompa
      * - Executes CompanyUserPreDeletePluginInterface plugins before delete company user.
      * - Deletes a company user.
      *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\CompanyUserTransfer $companyUserTransfer
      *
      * @return \Generated\Shared\Transfer\CompanyUserResponseTransfer
-     * @api
-     *
      */
     public function deleteCompanyUser(CompanyUserTransfer $companyUserTransfer): CompanyUserResponseTransfer
     {

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeInterface.php
@@ -30,11 +30,11 @@ interface CompanyTypeRoleToCompanyUserFacadeInterface
      * - Executes CompanyUserPreDeletePluginInterface plugins before delete company user.
      * - Deletes a company user.
      *
+     * @api
+     *
      * @param \Generated\Shared\Transfer\CompanyUserTransfer $companyUserTransfer
      *
      * @return \Generated\Shared\Transfer\CompanyUserResponseTransfer
-     * @api
-     *
      */
     public function deleteCompanyUser(CompanyUserTransfer $companyUserTransfer): CompanyUserResponseTransfer;
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Dependency/Facade/CompanyTypeRoleToCompanyUserFacadeInterface.php
@@ -4,6 +4,7 @@ namespace FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade;
 
 use Generated\Shared\Transfer\CompanyUserCollectionTransfer;
 use Generated\Shared\Transfer\CompanyUserCriteriaFilterTransfer;
+use Generated\Shared\Transfer\CompanyUserResponseTransfer;
 use Generated\Shared\Transfer\CompanyUserTransfer;
 
 interface CompanyTypeRoleToCompanyUserFacadeInterface
@@ -23,4 +24,17 @@ interface CompanyTypeRoleToCompanyUserFacadeInterface
     public function getCompanyUserCollection(
         CompanyUserCriteriaFilterTransfer $companyUserCriteriaFilterTransfer
     ): CompanyUserCollectionTransfer;
+
+    /**
+     * Specification:
+     * - Executes CompanyUserPreDeletePluginInterface plugins before delete company user.
+     * - Deletes a company user.
+     *
+     * @param \Generated\Shared\Transfer\CompanyUserTransfer $companyUserTransfer
+     *
+     * @return \Generated\Shared\Transfer\CompanyUserResponseTransfer
+     * @api
+     *
+     */
+    public function deleteCompanyUser(CompanyUserTransfer $companyUserTransfer): CompanyUserResponseTransfer;
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
@@ -3,9 +3,12 @@
 namespace FondOfImpala\Zed\CompanyTypeRole\Persistence;
 
 use Generated\Shared\Transfer\CompanyRoleCollectionTransfer;
+use Generated\Shared\Transfer\CompanyUserCollectionTransfer;
+use Generated\Shared\Transfer\CompanyUserTransfer;
 use Orm\Zed\CompanyRole\Persistence\Base\SpyCompanyRoleQuery;
 use Orm\Zed\CompanyRole\Persistence\Map\SpyCompanyRoleTableMap;
 use Orm\Zed\CompanyUser\Persistence\Map\SpyCompanyUserTableMap;
+use Orm\Zed\CompanyUser\Persistence\SpyCompanyUserQuery;
 use Orm\Zed\Permission\Persistence\Map\SpyPermissionTableMap;
 use Spryker\Zed\Kernel\Persistence\AbstractRepository;
 use Spryker\Zed\Propel\PropelConfig;
@@ -115,5 +118,28 @@ class CompanyTypeRoleRepository extends AbstractRepository implements CompanyTyp
         }
 
         return $companyRoleCollectionTransfer;
+    }
+
+    /**
+     * @param int $companyRoleId
+     * @return \Generated\Shared\Transfer\CompanyUserCollectionTransfer
+     * @throws \Spryker\Zed\Propel\Business\Exception\AmbiguousComparisonException
+     */
+    public function findCompanyUserIdsByCompanyRoleId(
+        int $companyRoleId
+    ): CompanyUserCollectionTransfer {
+        $spyCompanyUsers = SpyCompanyUserQuery::create()
+            ->useSpyCompanyRoleToCompanyUserQuery()
+                ->filterByFkCompanyRole($companyRoleId)
+            ->endUse()
+            ->find();
+
+        $collection = new CompanyUserCollectionTransfer();
+
+        foreach ($spyCompanyUsers as $spyCompanyUser) {
+            $collection->addCompanyUser((new CompanyUserTransfer())->fromArray($spyCompanyUser->toArray(), true));
+        }
+
+        return $collection;
     }
 }

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
@@ -122,8 +122,8 @@ class CompanyTypeRoleRepository extends AbstractRepository implements CompanyTyp
 
     /**
      * @param int $companyRoleId
+     *
      * @return \Generated\Shared\Transfer\CompanyUserCollectionTransfer
-     * @throws \Spryker\Zed\Propel\Business\Exception\AmbiguousComparisonException
      */
     public function findCompanyUserIdsByCompanyRoleId(
         int $companyRoleId

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepositoryInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepositoryInterface.php
@@ -38,8 +38,10 @@ interface CompanyTypeRoleRepositoryInterface
 
     /**
      * @param int $companyRoleId
-     * @return \Generated\Shared\Transfer\CompanyUserCollectionTransfer
+     *
      * @throws \Spryker\Zed\Propel\Business\Exception\AmbiguousComparisonException
+     *
+     * @return \Generated\Shared\Transfer\CompanyUserCollectionTransfer
      */
     public function findCompanyUserIdsByCompanyRoleId(
         int $companyRoleId

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepositoryInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepositoryInterface.php
@@ -3,6 +3,7 @@
 namespace FondOfImpala\Zed\CompanyTypeRole\Persistence;
 
 use Generated\Shared\Transfer\CompanyRoleCollectionTransfer;
+use Generated\Shared\Transfer\CompanyUserCollectionTransfer;
 
 interface CompanyTypeRoleRepositoryInterface
 {
@@ -34,4 +35,13 @@ interface CompanyTypeRoleRepositoryInterface
     public function findCompanyRolesByCompanyRoleIds(
         array $companyRoleIds
     ): CompanyRoleCollectionTransfer;
+
+    /**
+     * @param int $companyRoleId
+     * @return \Generated\Shared\Transfer\CompanyUserCollectionTransfer
+     * @throws \Spryker\Zed\Propel\Business\Exception\AmbiguousComparisonException
+     */
+    public function findCompanyUserIdsByCompanyRoleId(
+        int $companyRoleId
+    ): CompanyUserCollectionTransfer;
 }

--- a/bundles/company-type-role/tests/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleBusinessFactoryTest.php
+++ b/bundles/company-type-role/tests/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleBusinessFactoryTest.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\CompanyTypeRole\Business;
 use Codeception\Test\Unit;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleAssigner;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleAssignerInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleDeleter;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\PermissionReader;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Reader\AssignableCompanyRoleReader;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Synchronizer\PermissionSynchronizer;
@@ -215,6 +216,34 @@ class CompanyTypeRoleBusinessFactoryTest extends Unit
         static::assertInstanceOf(
             AssignableCompanyRoleReader::class,
             $this->companyTypeRoleBusinessFactory->createAssignableCompanyRoleReader(),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testCreateCompanyRoleDeleter(): void
+    {
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('has')
+            ->withConsecutive(
+                [CompanyTypeRoleDependencyProvider::FACADE_COMPANY_USER],
+                [CompanyTypeRoleDependencyProvider::FACADE_COMPANY_ROLE],
+            )->willReturnOnConsecutiveCalls(true, true);
+
+        $this->containerMock->expects(static::atLeastOnce())
+            ->method('get')
+            ->withConsecutive(
+                [CompanyTypeRoleDependencyProvider::FACADE_COMPANY_USER],
+                [CompanyTypeRoleDependencyProvider::FACADE_COMPANY_ROLE],
+            )->willReturnOnConsecutiveCalls(
+                $this->companyUserFacadeMock,
+                $this->companyRoleFacadeMock,
+            );
+
+        static::assertInstanceOf(
+            CompanyRoleDeleter::class,
+            $this->companyTypeRoleBusinessFactory->createCompanyRoleDeleter(),
         );
     }
 }

--- a/bundles/company-type-role/tests/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacadeTest.php
+++ b/bundles/company-type-role/tests/FondOfImpala/Zed/CompanyTypeRole/Business/CompanyTypeRoleFacadeTest.php
@@ -4,11 +4,15 @@ namespace FondOfImpala\Zed\CompanyTypeRole\Business;
 
 use Codeception\Test\Unit;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleAssignerInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Business\Model\CompanyRoleDeleter;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Reader\AssignableCompanyRoleReaderInterface;
 use FondOfImpala\Zed\CompanyTypeRole\Business\Synchronizer\PermissionSynchronizerInterface;
 use Generated\Shared\Transfer\AssignableCompanyRoleCriteriaFilterTransfer;
 use Generated\Shared\Transfer\CompanyResponseTransfer;
 use Generated\Shared\Transfer\CompanyRoleCollectionTransfer;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
+use Generated\Shared\Transfer\CompanyRoleTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class CompanyTypeRoleFacadeTest extends Unit
 {
@@ -52,6 +56,12 @@ class CompanyTypeRoleFacadeTest extends Unit
      */
     protected $assignableCompanyRoleReaderMock;
 
+    protected CompanyRoleDeleter|MockObject $companyRoleDeleterMock;
+
+    protected CompanyRoleTransfer|MockObject $companyRoleTransferMock;
+
+    protected CompanyRoleResponseTransfer|MockObject $companyRoleResponseTransferMock;
+
     /**
      * @return void
      */
@@ -84,6 +94,18 @@ class CompanyTypeRoleFacadeTest extends Unit
             ->getMock();
 
         $this->assignableCompanyRoleReaderMock = $this->getMockBuilder(AssignableCompanyRoleReaderInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleDeleterMock = $this->getMockBuilder(CompanyRoleDeleter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleTransferMock = $this->getMockBuilder(CompanyRoleTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleResponseTransferMock = $this->getMockBuilder(CompanyRoleResponseTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -146,6 +168,25 @@ class CompanyTypeRoleFacadeTest extends Unit
             $this->companyTypeRoleFacade->getAssignableCompanyRoles(
                 $this->assignableCompanyRoleCriteriaFilterTransferMock,
             ),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteCompanyRoleAndCompanyUserByCompanyRole(): void
+    {
+        $this->companyTypeRoleBusinessFactoryMock->expects(static::atLeastOnce())
+            ->method('createCompanyRoleDeleter')
+            ->willReturn($this->companyRoleDeleterMock);
+
+        $this->companyRoleDeleterMock->expects(static::atLeastOnce())
+            ->method('deleteCompanyRoleAndCompanyUserByCompanyRole')
+            ->with($this->companyRoleTransferMock)
+            ->willReturn($this->companyRoleResponseTransferMock);
+
+        $this->companyTypeRoleFacade->deleteCompanyRoleAndCompanyUserByCompanyRole(
+            $this->companyRoleTransferMock,
         );
     }
 }

--- a/bundles/company-type-role/tests/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleterTest.php
+++ b/bundles/company-type-role/tests/FondOfImpala/Zed/CompanyTypeRole/Business/Model/CompanyRoleDeleterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace FondOfImpala\Zed\CompanyTypeRole\Business\Model;
+
+use ArrayObject;
+use Codeception\Test\Unit;
+use FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade\CompanyTypeRoleToCompanyRoleFacadeInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Dependency\Facade\CompanyTypeRoleToCompanyUserFacadeInterface;
+use FondOfImpala\Zed\CompanyTypeRole\Persistence\CompanyTypeRoleRepositoryInterface;
+use Generated\Shared\Transfer\CompanyRoleResponseTransfer;
+use Generated\Shared\Transfer\CompanyRoleTransfer;
+use Generated\Shared\Transfer\CompanyUserCollectionTransfer;
+use Generated\Shared\Transfer\CompanyUserTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class CompanyRoleDeleterTest extends Unit
+{
+    protected CompanyTypeRoleToCompanyRoleFacadeInterface|MockObject $companyRoleFacadeMock;
+
+    protected CompanyTypeRoleToCompanyUserFacadeInterface|MockObject $companyUserFacadeMock;
+
+    protected CompanyTypeRoleRepositoryInterface|MockObject $repositoryMock;
+
+    protected CompanyRoleTransfer|MockObject $companyRoleTransferMock;
+
+    protected CompanyRoleResponseTransfer|MockObject $companyRoleResponseTransferMock;
+
+    protected CompanyUserCollectionTransfer|MockObject $companyUserCollectionTransferMock;
+
+    protected CompanyUserTransfer|MockObject $companyUserTransferMock;
+
+    protected CompanyRoleDeleter $companyRoleDeleter;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->companyRoleFacadeMock = $this->getMockBuilder(CompanyTypeRoleToCompanyRoleFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserFacadeMock = $this->getMockBuilder(CompanyTypeRoleToCompanyUserFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->repositoryMock = $this->getMockBuilder(CompanyTypeRoleRepositoryInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleTransferMock = $this->getMockBuilder(CompanyRoleTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleResponseTransferMock = $this->getMockBuilder(CompanyRoleResponseTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserCollectionTransferMock = $this->getMockBuilder(CompanyUserCollectionTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyUserTransferMock = $this->getMockBuilder(CompanyUserTransfer::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->companyRoleDeleter = new CompanyRoleDeleter(
+            $this->companyUserFacadeMock,
+            $this->companyRoleFacadeMock,
+            $this->repositoryMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteCompanyRoleAndCompanyUserByCompanyRoleWithNoCompanyUserToDelete(): void
+    {
+        $this->companyRoleTransferMock->expects($this->atLeastOnce())
+            ->method('getIdCompanyRole')
+            ->willReturn(1);
+
+        $this->repositoryMock->expects($this->atLeastOnce())
+            ->method('findCompanyUserIdsByCompanyRoleId')
+            ->willReturn($this->companyUserCollectionTransferMock);
+
+        $this->companyUserCollectionTransferMock->expects($this->atLeastOnce())
+            ->method('getCompanyUsers')
+            ->willReturn(new ArrayObject());
+
+        $this->companyUserFacadeMock->expects($this->never())
+            ->method('deleteCompanyUser');
+
+        $this->companyRoleFacadeMock->expects($this->atLeastOnce())
+            ->method('delete')->willReturn($this->companyRoleResponseTransferMock);
+
+        $this->companyRoleDeleter
+            ->deleteCompanyRoleAndCompanyUserByCompanyRole($this->companyRoleTransferMock);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDeleteCompanyRoleAndCompanyUserByCompanyRole(): void
+    {
+        $this->companyRoleTransferMock->expects($this->atLeastOnce())
+            ->method('getIdCompanyRole')
+            ->willReturn(1);
+
+        $this->repositoryMock->expects($this->atLeastOnce())
+            ->method('findCompanyUserIdsByCompanyRoleId')
+            ->willReturn($this->companyUserCollectionTransferMock);
+
+        $this->companyUserCollectionTransferMock->expects($this->atLeastOnce())
+            ->method('getCompanyUsers')
+            ->willReturn(new ArrayObject([$this->companyUserTransferMock]));
+
+        $this->companyUserFacadeMock->expects($this->atLeastOnce())
+            ->method('deleteCompanyUser')
+            ->with($this->companyUserTransferMock);
+
+        $this->companyRoleFacadeMock->expects($this->atLeastOnce())
+            ->method('delete')->willReturn($this->companyRoleResponseTransferMock);
+
+        $this->companyRoleDeleter
+            ->deleteCompanyRoleAndCompanyUserByCompanyRole($this->companyRoleTransferMock);
+    }
+}


### PR DESCRIPTION
on company role deletions, delete company user first, since the role could not be deleted if the role is still assigned. The company user needs to be deleted first, since its not allowed to have company users without role assigned