### PR TITLE
feat: refresh conditional availability periods directly

### DIFF
--- a/bundles/product-list-conditional-availability-page-search/composer.json
+++ b/bundles/product-list-conditional-availability-page-search/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": ">=8.0",
     "fond-of-impala/conditional-availability":  "^1.0.0 || ^2.0.0",
-    "fond-of-impala/conditional-availability-page-search":  "^1.0.0 || ^2.0.0",
+    "fond-of-impala/conditional-availability-page-search":  "^2.2.0",
     "fond-of-impala/conditional-availability-page-search-extension": "^1.0.0",
     "spryker/customer": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
     "spryker/event": "^1.0.0 || ^2.0.0",

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/Plugin/SearchExtension/ProductListConditionalAvailabilityPageSearchQueryExpanderPlugin.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/Plugin/SearchExtension/ProductListConditionalAvailabilityPageSearchQueryExpanderPlugin.php
@@ -98,7 +98,7 @@ class ProductListConditionalAvailabilityPageSearchQueryExpanderPlugin extends Ab
     {
         $customerProductListCollectionTransfer = $this->findCustomerProductListCollection();
 
-        if (!$customerProductListCollectionTransfer) {
+        if ($customerProductListCollectionTransfer === null) {
             return [];
         }
 
@@ -112,7 +112,7 @@ class ProductListConditionalAvailabilityPageSearchQueryExpanderPlugin extends Ab
     {
         $customerProductListCollectionTransfer = $this->findCustomerProductListCollection();
 
-        if (!$customerProductListCollectionTransfer) {
+        if ($customerProductListCollectionTransfer === null) {
             return [];
         }
 

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Model/ConditionalAvailabilityPeriodPageSearchExpander.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Model/ConditionalAvailabilityPeriodPageSearchExpander.php
@@ -2,21 +2,21 @@
 
 namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Model;
 
-use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader\ProductListReaderInterface;
 use Generated\Shared\Transfer\ConditionalAvailabilityPeriodPageSearchTransfer;
 use Generated\Shared\Transfer\ProductListMapTransfer;
 
 class ConditionalAvailabilityPeriodPageSearchExpander implements ConditionalAvailabilityPeriodPageSearchExpanderInterface
 {
-    protected ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacade;
+    protected ProductListReaderInterface $productListReader;
 
     /**
-     * @param \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacade
+     * @param \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader\ProductListReaderInterface $productListReader
      */
     public function __construct(
-        ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacade
+        ProductListReaderInterface $productListReader
     ) {
-        $this->productListFacade = $productListFacade;
+        $this->productListReader = $productListReader;
     }
 
     /**
@@ -54,7 +54,7 @@ class ConditionalAvailabilityPeriodPageSearchExpander implements ConditionalAvai
     ): ConditionalAvailabilityPeriodPageSearchTransfer {
         $idProduct = $conditionalAvailabilityPeriodPageSearchTransfer->getFkProduct();
 
-        $whitelists = $this->productListFacade->getProductWhitelistIdsByIdProduct($idProduct);
+        $whitelists = $this->productListReader->getWhitelistIdsByIdProduct($idProduct);
 
         if ($whitelists) {
             $conditionalAvailabilityPeriodPageSearchTransfer->getProductListMap()->setWhitelists($whitelists);
@@ -73,7 +73,7 @@ class ConditionalAvailabilityPeriodPageSearchExpander implements ConditionalAvai
     ): ConditionalAvailabilityPeriodPageSearchTransfer {
         $idProduct = $conditionalAvailabilityPeriodPageSearchTransfer->getFkProduct();
 
-        $blacklists = $this->productListFacade->getProductBlacklistIdsByIdProduct($idProduct);
+        $blacklists = $this->productListReader->getBlacklistIdsByIdProduct($idProduct);
 
         if ($blacklists) {
             $conditionalAvailabilityPeriodPageSearchTransfer->getProductListMap()->setBlacklists($blacklists);

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/ProductListConditionalAvailabilityPageSearchBusinessFactory.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/ProductListConditionalAvailabilityPageSearchBusinessFactory.php
@@ -4,6 +4,8 @@ namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business
 
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Model\ConditionalAvailabilityPeriodPageSearchExpander;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Model\ConditionalAvailabilityPeriodPageSearchExpanderInterface;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader\ProductListReader;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader\ProductListReaderInterface;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\ProductListConditionalAvailabilityPageSearchDependencyProvider;
 use Spryker\Zed\Kernel\Business\AbstractBusinessFactory;
@@ -16,6 +18,16 @@ class ProductListConditionalAvailabilityPageSearchBusinessFactory extends Abstra
     public function createConditionalAvailabilityPeriodPageSearchExpander(): ConditionalAvailabilityPeriodPageSearchExpanderInterface
     {
         return new ConditionalAvailabilityPeriodPageSearchExpander(
+            $this->createProductListReader(),
+        );
+    }
+
+    /**
+     * @return \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader\ProductListReaderInterface
+     */
+    protected function createProductListReader(): ProductListReaderInterface
+    {
+        return new ProductListReader(
             $this->getProductListFacade(),
         );
     }

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Reader/ProductListReader.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Reader/ProductListReader.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader;
+
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface;
+
+class ProductListReader implements ProductListReaderInterface
+{
+    /**
+     * @var array<int, array<int>>
+     */
+    protected static array $whitelistIdsPerIdProduct = [];
+
+    /**
+     * @var array<int, array<int>>
+     */
+    protected static array $blacklistIdsPerIdProduct = [];
+
+    protected ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacade;
+
+    /**
+     * @param \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacade
+     */
+    public function __construct(
+        ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacade
+    ) {
+        $this->productListFacade = $productListFacade;
+    }
+
+    /**
+     * @param int $idProduct
+     *
+     * @return array<int>
+     */
+    public function getBlacklistIdsByIdProduct(int $idProduct): array
+    {
+        if (isset(static::$blacklistIdsPerIdProduct[$idProduct])) {
+            return static::$blacklistIdsPerIdProduct[$idProduct];
+        }
+
+        static::$blacklistIdsPerIdProduct[$idProduct] = $this->productListFacade->getProductBlacklistIdsByIdProduct(
+            $idProduct,
+        );
+
+        return static::$blacklistIdsPerIdProduct[$idProduct];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getWhitelistIdsByIdProduct(int $idProduct): array
+    {
+        if (isset(static::$whitelistIdsPerIdProduct[$idProduct])) {
+            return static::$whitelistIdsPerIdProduct[$idProduct];
+        }
+
+        static::$whitelistIdsPerIdProduct[$idProduct] = $this->productListFacade->getProductWhitelistIdsByIdProduct(
+            $idProduct,
+        );
+
+        return static::$whitelistIdsPerIdProduct[$idProduct];
+    }
+}

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Reader/ProductListReaderInterface.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Reader/ProductListReaderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader;
+
+interface ProductListReaderInterface
+{
+    /**
+     * @param int $idProduct
+     *
+     * @return array<int>
+     */
+    public function getBlacklistIdsByIdProduct(int $idProduct): array;
+
+    /**
+     * @param int $idProduct
+     *
+     * @return array<int>
+     */
+    public function getWhitelistIdsByIdProduct(int $idProduct): array;
+}

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/Plugin/Event/Listener/ProductListProductConcreteListener.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/Plugin/Event/Listener/ProductListProductConcreteListener.php
@@ -2,7 +2,6 @@
 
 namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Communication\Plugin\Event\Listener;
 
-use FondOfImpala\Shared\ConditionalAvailabilityPageSearch\ConditionalAvailabilityPageSearchConstants;
 use Orm\Zed\ProductList\Persistence\Map\SpyProductListProductConcreteTableMap;
 use Spryker\Zed\Event\Dependency\Plugin\EventBulkHandlerInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
@@ -32,8 +31,7 @@ class ProductListProductConcreteListener extends AbstractPlugin implements Event
         $conditionalAvailabilityIds = $this->getFactory()->getConditionalAvailabilityFacade()
             ->getConditionalAvailabilityIdsByProductConcreteIds($concreteIds);
 
-        $this->getFactory()->getEventBehaviorFacade()->executeResolvedPluginsBySources(
-            [ConditionalAvailabilityPageSearchConstants::CONDITIONAL_AVAILABILITY_PERIOD_RESOURCE_NAME],
+        $this->getFactory()->getConditionalAvailabilityPageSearchFacade()->publishByConditionalAvailabilityIds(
             $conditionalAvailabilityIds,
         );
     }

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ProductListConditionalAvailabilityPageSearchCommunicationFactory.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ProductListConditionalAvailabilityPageSearchCommunicationFactory.php
@@ -3,6 +3,7 @@
 namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Communication;
 
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeInterface;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\ProductListConditionalAvailabilityPageSearchDependencyProvider;
 use Spryker\Zed\Kernel\Communication\AbstractCommunicationFactory;
@@ -19,6 +20,16 @@ class ProductListConditionalAvailabilityPageSearchCommunicationFactory extends A
     {
         return $this->getProvidedDependency(
             ProductListConditionalAvailabilityPageSearchDependencyProvider::FACADE_CONDITIONAL_AVAILABILITY,
+        );
+    }
+
+    /**
+     * @return \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface
+     */
+    public function getConditionalAvailabilityPageSearchFacade(): ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface
+    {
+        return $this->getProvidedDependency(
+            ProductListConditionalAvailabilityPageSearchDependencyProvider::FACADE_CONDITIONAL_AVAILABILITY_PAGE_SEARCH,
         );
     }
 

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade;
+
+use FondOfImpala\Zed\ConditionalAvailabilityPageSearch\Business\ConditionalAvailabilityPageSearchFacadeInterface;
+
+class ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge implements ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface
+{
+    protected ConditionalAvailabilityPageSearchFacadeInterface $conditionalAvailabilityPageSearchFacade;
+
+    /**
+     * @param \FondOfImpala\Zed\ConditionalAvailabilityPageSearch\Business\ConditionalAvailabilityPageSearchFacadeInterface $conditionalAvailabilityPageSearchFacade
+     */
+    public function __construct(
+        ConditionalAvailabilityPageSearchFacadeInterface $conditionalAvailabilityPageSearchFacade
+    ) {
+        $this->conditionalAvailabilityPageSearchFacade = $conditionalAvailabilityPageSearchFacade;
+    }
+
+    /**
+     * @param array<int> $conditionalAvailabilityIds
+     *
+     * @return void
+     */
+    public function publishByConditionalAvailabilityIds(array $conditionalAvailabilityIds): void
+    {
+        $this->conditionalAvailabilityPageSearchFacade->publishByConditionalAvailabilityIds(
+            $conditionalAvailabilityIds,
+        );
+    }
+}

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade;
+
+interface ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface
+{
+    /**
+     * @param array<int> $conditionalAvailabilityIds
+     *
+     * @return void
+     */
+    public function publishByConditionalAvailabilityIds(array $conditionalAvailabilityIds): void;
+}

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge.php
@@ -26,23 +26,4 @@ class ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge im
     {
         return $this->eventBehaviorFacade->getEventTransferForeignKeys($eventTransfers, $foreignKeyColumnName);
     }
-
-    /**
-     * @param array<string> $resources
-     * @param array<int> $ids
-     * @param array<\Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourcePluginInterface> $resourcePublisherPlugins
-     *
-     * @return void
-     */
-    public function executeResolvedPluginsBySources(
-        array $resources,
-        array $ids = [],
-        array $resourcePublisherPlugins = []
-    ): void {
-        $this->eventBehaviorFacade->executeResolvedPluginsBySources(
-            $resources,
-            $ids,
-            $resourcePublisherPlugins,
-        );
-    }
 }

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface.php
@@ -11,17 +11,4 @@ interface ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInter
      * @return array
      */
     public function getEventTransferForeignKeys(array $eventTransfers, $foreignKeyColumnName): array;
-
-    /**
-     * @param array<string> $resources
-     * @param array<int> $ids
-     * @param array<\Spryker\Zed\EventBehavior\Dependency\Plugin\EventResourcePluginInterface> $resourcePublisherPlugins
-     *
-     * @return void
-     */
-    public function executeResolvedPluginsBySources(
-        array $resources,
-        array $ids = [],
-        array $resourcePublisherPlugins = []
-    ): void;
 }

--- a/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchDependencyProvider.php
+++ b/bundles/product-list-conditional-availability-page-search/src/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchDependencyProvider.php
@@ -3,8 +3,13 @@
 namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch;
 
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridge;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeInterface;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface;
 use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeBridge;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface;
 use Spryker\Zed\Kernel\AbstractBundleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
 
@@ -22,6 +27,11 @@ class ProductListConditionalAvailabilityPageSearchDependencyProvider extends Abs
      * @var string
      */
     public const FACADE_CONDITIONAL_AVAILABILITY = 'FACADE_CONDITIONAL_AVAILABILITY';
+
+    /**
+     * @var string
+     */
+    public const FACADE_CONDITIONAL_AVAILABILITY_PAGE_SEARCH = 'FACADE_CONDITIONAL_AVAILABILITY_PAGE_SEARCH';
 
     /**
      * @var string
@@ -50,8 +60,9 @@ class ProductListConditionalAvailabilityPageSearchDependencyProvider extends Abs
         $container = parent::provideCommunicationLayerDependencies($container);
 
         $container = $this->addEventBehaviorFacade($container);
+        $container = $this->addConditionalAvailabilityFacade($container);
 
-        return $this->addConditionalAvailabilityFacade($container);
+        return $this->addConditionalAvailabilityPageSearchFacade($container);
     }
 
     /**
@@ -63,7 +74,7 @@ class ProductListConditionalAvailabilityPageSearchDependencyProvider extends Abs
     {
         $container[static::FACADE_PRODUCT_LIST] = static fn (
             Container $container
-        ): ProductListConditionalAvailabilityPageSearchToProductListFacadeBridge => new ProductListConditionalAvailabilityPageSearchToProductListFacadeBridge(
+        ): ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface => new ProductListConditionalAvailabilityPageSearchToProductListFacadeBridge(
             $container->getLocator()->productList()->facade(),
         );
 
@@ -79,7 +90,7 @@ class ProductListConditionalAvailabilityPageSearchDependencyProvider extends Abs
     {
         $container[static::FACADE_EVENT_BEHAVIOR] = static fn (
             Container $container
-        ): ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge => new ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge(
+        ): ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface => new ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge(
             $container->getLocator()->eventBehavior()->facade(),
         );
 
@@ -95,8 +106,24 @@ class ProductListConditionalAvailabilityPageSearchDependencyProvider extends Abs
     {
         $container[static::FACADE_CONDITIONAL_AVAILABILITY] = static fn (
             Container $container
-        ): ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridge => new ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridge(
+        ): ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeInterface => new ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridge(
             $container->getLocator()->conditionalAvailability()->facade(),
+        );
+
+        return $container;
+    }
+
+    /**
+     * @param \Spryker\Zed\Kernel\Container $container
+     *
+     * @return \Spryker\Zed\Kernel\Container
+     */
+    protected function addConditionalAvailabilityPageSearchFacade(Container $container): Container
+    {
+        $container[static::FACADE_CONDITIONAL_AVAILABILITY_PAGE_SEARCH] = static fn (
+            Container $container
+        ): ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeInterface => new ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge(
+            $container->getLocator()->conditionalAvailabilityPageSearch()->facade(),
         );
 
         return $container;

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/Dependency/Client/ProductListConditionalAvailabilityPageSearchToCustomerClientBridgeTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/Dependency/Client/ProductListConditionalAvailabilityPageSearchToCustomerClientBridgeTest.php
@@ -9,19 +9,10 @@ use Spryker\Client\Customer\CustomerClientInterface;
 
 class ProductListConditionalAvailabilityPageSearchToCustomerClientBridgeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\Dependency\Client\ProductListConditionalAvailabilityPageSearchToCustomerClientBridge
-     */
     protected ProductListConditionalAvailabilityPageSearchToCustomerClientBridge $bridge;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Customer\CustomerClientInterface
-     */
     protected MockObject|CustomerClientInterface $customerClientInterfaceMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\CustomerTransfer
-     */
     protected MockObject|CustomerTransfer $customerTransferMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/Plugin/SearchExtension/ProductListConditionalAvailabilityPageSearchQueryExpanderPluginTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/Plugin/SearchExtension/ProductListConditionalAvailabilityPageSearchQueryExpanderPluginTest.php
@@ -17,29 +17,14 @@ use Spryker\Client\SearchExtension\Dependency\Plugin\QueryInterface;
 
 class ProductListConditionalAvailabilityPageSearchQueryExpanderPluginTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\Plugin\SearchExtension\ProductListConditionalAvailabilityPageSearchQueryExpanderPlugin
-     */
     protected ProductListConditionalAvailabilityPageSearchQueryExpanderPlugin $plugin;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\SearchExtension\Dependency\Plugin\QueryInterface
-     */
     protected MockObject|QueryInterface $queryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Elastica\Query
-     */
     protected MockObject|ElasticaQuery $elasticaQueryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\ProductListConditionalAvailabilityPageSearchFactory
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchFactory $factoryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\Dependency\Client\ProductListConditionalAvailabilityPageSearchToCustomerClientInterface
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchToCustomerClientInterface $customerClientMock;
 
     /**
@@ -289,10 +274,10 @@ class ProductListConditionalAvailabilityPageSearchQueryExpanderPluginTest extend
 
         try {
             $this->plugin->expandQuery($this->queryMock);
-        } catch (InvalidArgumentException $exception) {
+        } catch (InvalidArgumentException $invalidArgumentException) {
             static::assertInstanceOf(
                 InvalidArgumentException::class,
-                $exception,
+                $invalidArgumentException,
             );
         }
     }

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchDependencyProviderTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchDependencyProviderTest.php
@@ -8,14 +8,8 @@ use Spryker\Client\Kernel\Container;
 
 class ProductListConditionalAvailabilityPageSearchDependencyProviderTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\ProductListConditionalAvailabilityPageSearchDependencyProvider
-     */
     protected ProductListConditionalAvailabilityPageSearchDependencyProvider $dependencyProvider;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Kernel\Container
-     */
     protected MockObject|Container $containerMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchFactoryTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Client/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchFactoryTest.php
@@ -9,19 +9,10 @@ use Spryker\Client\Kernel\Container;
 
 class ProductListConditionalAvailabilityPageSearchFactoryTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\ProductListConditionalAvailabilityPageSearchFactory
-     */
     protected ProductListConditionalAvailabilityPageSearchFactory $factory;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Client\Kernel\Container
-     */
     protected MockObject|Container $containerMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Client\ProductListConditionalAvailabilityPageSearch\Dependency\Client\ProductListConditionalAvailabilityPageSearchToCustomerClientInterface
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchToCustomerClientInterface $customerClientMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Model/ConditionalAvailabilityPeriodPageSearchExpanderTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Model/ConditionalAvailabilityPeriodPageSearchExpanderTest.php
@@ -3,31 +3,19 @@
 namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Model;
 
 use Codeception\Test\Unit;
-use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader\ProductListReaderInterface;
 use Generated\Shared\Transfer\ConditionalAvailabilityPeriodPageSearchTransfer;
 use Generated\Shared\Transfer\ProductListMapTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Model\ConditionalAvailabilityPeriodPageSearchExpander
-     */
     protected ConditionalAvailabilityPeriodPageSearchExpander $expander;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface
-     */
-    protected MockObject|ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacadeMock;
+    protected MockObject|ProductListReaderInterface $productListReaderMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ConditionalAvailabilityPeriodPageSearchTransfer
-     */
     protected MockObject|ConditionalAvailabilityPeriodPageSearchTransfer $conditionalAvailabilityPeriodPageSearchTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ProductListMapTransfer
-     */
     protected MockObject|ProductListMapTransfer $productListMapTransferMock;
 
     /**
@@ -35,7 +23,7 @@ class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
      */
     protected function _before(): void
     {
-        $this->productListFacadeMock = $this->getMockBuilder(ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface::class)
+        $this->productListReaderMock = $this->getMockBuilder(ProductListReaderInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -48,7 +36,7 @@ class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
             ->getMock();
 
         $this->expander = new ConditionalAvailabilityPeriodPageSearchExpander(
-            $this->productListFacadeMock,
+            $this->productListReaderMock,
         );
     }
 
@@ -73,8 +61,8 @@ class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
             ->method('getFkProduct')
             ->willReturn($fkProduct);
 
-        $this->productListFacadeMock->expects(static::atLeastOnce())
-            ->method('getProductWhitelistIdsByIdProduct')
+        $this->productListReaderMock->expects(static::atLeastOnce())
+            ->method('getWhitelistIdsByIdProduct')
             ->with($fkProduct)
             ->willReturn($whitelistIds);
 
@@ -83,8 +71,8 @@ class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
             ->with($whitelistIds)
             ->willReturnSelf();
 
-        $this->productListFacadeMock->expects(static::atLeastOnce())
-            ->method('getProductBlacklistIdsByIdProduct')
+        $this->productListReaderMock->expects(static::atLeastOnce())
+            ->method('getBlacklistIdsByIdProduct')
             ->with($fkProduct)
             ->willReturn($blacklistIds);
 
@@ -122,8 +110,8 @@ class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
             ->method('getFkProduct')
             ->willReturn($fkProduct);
 
-        $this->productListFacadeMock->expects(static::atLeastOnce())
-            ->method('getProductWhitelistIdsByIdProduct')
+        $this->productListReaderMock->expects(static::atLeastOnce())
+            ->method('getWhitelistIdsByIdProduct')
             ->with($fkProduct)
             ->willReturn($whitelistIds);
 
@@ -132,8 +120,8 @@ class ConditionalAvailabilityPeriodPageSearchExpanderTest extends Unit
             ->with($whitelistIds)
             ->willReturnSelf();
 
-        $this->productListFacadeMock->expects(static::atLeastOnce())
-            ->method('getProductBlacklistIdsByIdProduct')
+        $this->productListReaderMock->expects(static::atLeastOnce())
+            ->method('getBlacklistIdsByIdProduct')
             ->with($fkProduct)
             ->willReturn($blacklistIds);
 

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/ProductListConditionalAvailabilityPageSearchBusinessFactoryTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/ProductListConditionalAvailabilityPageSearchBusinessFactoryTest.php
@@ -11,19 +11,10 @@ use Spryker\Zed\Kernel\Container;
 
 class ProductListConditionalAvailabilityPageSearchBusinessFactoryTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\ProductListConditionalAvailabilityPageSearchBusinessFactory
-     */
     protected ProductListConditionalAvailabilityPageSearchBusinessFactory $factory;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container
-     */
     protected MockObject|Container $containerMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface $productListFacadeMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/ProductListConditionalAvailabilityPageSearchFacadeTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/ProductListConditionalAvailabilityPageSearchFacadeTest.php
@@ -9,24 +9,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ProductListConditionalAvailabilityPageSearchFacadeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\ProductListConditionalAvailabilityPageSearchFacade
-     */
     protected ProductListConditionalAvailabilityPageSearchFacade $facade;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\ProductListConditionalAvailabilityPageSearchBusinessFactory
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchBusinessFactory $factoryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ConditionalAvailabilityPeriodPageSearchTransfer
-     */
     protected MockObject|ConditionalAvailabilityPeriodPageSearchTransfer $conditionalAvailabilityPeriodPageSearchTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Model\ConditionalAvailabilityPeriodPageSearchExpanderInterface
-     */
     protected MockObject|ConditionalAvailabilityPeriodPageSearchExpanderInterface $conditionalAvailabilityPeriodPageSearchExpanderMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Reader/ProductListReaderTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Business/Reader/ProductListReaderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\Reader;
+
+use Codeception\Test\Unit;
+use FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ProductListReaderTest extends Unit
+{
+    protected ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface|MockObject $productListFacadeMock;
+
+    protected ProductListReader $productListReader;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        parent::_before();
+
+        $this->productListFacadeMock = $this->getMockBuilder(ProductListConditionalAvailabilityPageSearchToProductListFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->productListReader = new ProductListReader(
+            $this->productListFacadeMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetWhitelistIdsByIdProduct(): void
+    {
+        $idProduct = 1;
+        $whitelistIds = [2, 3, 6];
+
+        $this->productListFacadeMock->expects(static::atLeastOnce())
+            ->method('getProductWhitelistIdsByIdProduct')
+            ->with($idProduct)
+            ->willReturn($whitelistIds);
+
+        static::assertEquals(
+            $whitelistIds,
+            $this->productListReader->getWhitelistIdsByIdProduct($idProduct),
+        );
+    }
+
+    /**
+     * @depends testGetWhitelistIdsByIdProduct
+     *
+     * @return void
+     */
+    public function testGetWhitelistIdsByIdProductWithCache(): void
+    {
+        $idProduct = 1;
+        $whitelistIds = [2, 3, 6];
+
+        $this->productListFacadeMock->expects(static::never())
+            ->method('getProductWhitelistIdsByIdProduct');
+
+        static::assertEquals(
+            $whitelistIds,
+            $this->productListReader->getWhitelistIdsByIdProduct($idProduct),
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testGetBlacklistIdsByIdProduct(): void
+    {
+        $idProduct = 1;
+        $whitelistIds = [2, 3, 6];
+
+        $this->productListFacadeMock->expects(static::atLeastOnce())
+            ->method('getProductBlacklistIdsByIdProduct')
+            ->with($idProduct)
+            ->willReturn($whitelistIds);
+
+        static::assertEquals(
+            $whitelistIds,
+            $this->productListReader->getBlacklistIdsByIdProduct($idProduct),
+        );
+    }
+
+    /**
+     * @depends testGetBlacklistIdsByIdProduct
+     *
+     * @return void
+     */
+    public function testGetBlacklistIdsByIdProductWithCache(): void
+    {
+        $idProduct = 1;
+        $whitelistIds = [2, 3, 6];
+
+        $this->productListFacadeMock->expects(static::never())
+            ->method('getProductBlacklistIdsByIdProduct');
+
+        static::assertEquals(
+            $whitelistIds,
+            $this->productListReader->getBlacklistIdsByIdProduct($idProduct),
+        );
+    }
+}

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ConditionalAvailabilityPageSearchExtension/ProductListConditionalAvailabilityPeriodPageDataExpanderPluginTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ConditionalAvailabilityPageSearchExtension/ProductListConditionalAvailabilityPeriodPageDataExpanderPluginTest.php
@@ -10,19 +10,10 @@ use Spryker\Zed\Kernel\Business\AbstractFacade;
 
 class ProductListConditionalAvailabilityPeriodPageDataExpanderPluginTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Communication\ConditionalAvailabilityPageSearchExtension\ProductListConditionalAvailabilityPeriodPageDataExpanderPlugin
-     */
     protected ProductListConditionalAvailabilityPeriodPageDataExpanderPlugin $plugin;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Business\ProductListConditionalAvailabilityPageSearchFacade
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchFacade $facadeMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ConditionalAvailabilityPeriodPageSearchTransfer
-     */
     protected MockObject|ConditionalAvailabilityPeriodPageSearchTransfer $conditionalAvailabilityPeriodPageSearchTransferMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ConditionalAvailabilityPageSearchExtension/ProductListConditionalAvailabilityPeriodPageSearchDataExpanderPluginTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ConditionalAvailabilityPageSearchExtension/ProductListConditionalAvailabilityPeriodPageSearchDataExpanderPluginTest.php
@@ -6,9 +6,6 @@ use Codeception\Test\Unit;
 
 class ProductListConditionalAvailabilityPeriodPageSearchDataExpanderPluginTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Communication\ConditionalAvailabilityPageSearchExtension\ProductListConditionalAvailabilityPeriodPageSearchDataExpanderPlugin
-     */
     protected ProductListConditionalAvailabilityPeriodPageSearchDataExpanderPlugin $plugin;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/Plugin/Event/Subscriber/ProductListConditionalAvailabilityPageSearchEventSubscriberTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/Plugin/Event/Subscriber/ProductListConditionalAvailabilityPageSearchEventSubscriberTest.php
@@ -10,14 +10,8 @@ use Spryker\Zed\ProductList\Dependency\ProductListEvents;
 
 class ProductListConditionalAvailabilityPageSearchEventSubscriberTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Communication\Plugin\Event\Subscriber\ProductListConditionalAvailabilityPageSearchEventSubscriber
-     */
     protected ProductListConditionalAvailabilityPageSearchEventSubscriber $subscriber;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Event\Dependency\EventCollectionInterface
-     */
     protected MockObject|EventCollectionInterface $eventCollectionMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ProductListConditionalAvailabilityPageSearchCommunicationFactoryTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Communication/ProductListConditionalAvailabilityPageSearchCommunicationFactoryTest.php
@@ -11,24 +11,12 @@ use Spryker\Zed\Kernel\Container;
 
 class ProductListConditionalAvailabilityPageSearchCommunicationFactoryTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Communication\ProductListConditionalAvailabilityPageSearchCommunicationFactory
-     */
     protected ProductListConditionalAvailabilityPageSearchCommunicationFactory $factory;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container
-     */
     protected MockObject|Container $containerMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeInterface
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeInterface $conditionalAvailabilityFacadeMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeInterface $eventBehaviorFacadeMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridgeTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridgeTest.php
@@ -8,14 +8,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridgeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridge
-     */
     protected ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityFacadeBridge $bridge;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ConditionalAvailability\Business\ConditionalAvailabilityFacadeInterface
-     */
     protected MockObject|ConditionalAvailabilityFacadeInterface $facadeMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridgeTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridgeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade;
+
+use Codeception\Test\Unit;
+use FondOfImpala\Zed\ConditionalAvailabilityPageSearch\Business\ConditionalAvailabilityPageSearchFacadeInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridgeTest extends Unit
+{
+    protected ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge $bridge;
+
+    protected MockObject|ConditionalAvailabilityPageSearchFacadeInterface $facadeMock;
+
+    /**
+     * @return void
+     */
+    protected function _before(): void
+    {
+        $this->facadeMock = $this->getMockBuilder(ConditionalAvailabilityPageSearchFacadeInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->bridge = new ProductListConditionalAvailabilityPageSearchToConditionalAvailabilityPageSearchFacadeBridge(
+            $this->facadeMock,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testPublishByConditionalAvailabilityIds(): void
+    {
+        $conditionalAvailabilityIds = [1, 2];
+
+        $this->facadeMock->expects(static::atLeastOnce())
+            ->method('publishByConditionalAvailabilityIds')
+            ->with($conditionalAvailabilityIds);
+
+        $this->bridge->publishByConditionalAvailabilityIds($conditionalAvailabilityIds);
+    }
+}

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridgeTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridgeTest.php
@@ -9,14 +9,8 @@ use Spryker\Zed\EventBehavior\Business\EventBehaviorFacadeInterface;
 
 class ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridgeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge
-     */
     protected ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridge $bridge;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\EventBehavior\Business\EventBehaviorFacadeInterface
-     */
     protected MockObject|EventBehaviorFacadeInterface $eventBehaviorFacadeMock;
 
     /**
@@ -24,9 +18,6 @@ class ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridgeTes
      */
     protected array $eventTransfers;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\EventEntityTransfer
-     */
     protected MockObject|EventEntityTransfer $eventEntityTransferMock;
 
     /**
@@ -69,25 +60,6 @@ class ProductListConditionalAvailabilityPageSearchToEventBehaviorFacadeBridgeTes
                 $eventTransfers,
                 $foreignKeyColumnName,
             ),
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testExecuteResolvedPluginsBySources(): void
-    {
-        $resources = ['foo'];
-        $ids = [1, 2, 4, 5];
-
-        $this->eventBehaviorFacadeMock->expects(static::atLeastOnce())
-            ->method('executeResolvedPluginsBySources')
-            ->with($resources, $ids, []);
-
-        $this->bridge->executeResolvedPluginsBySources(
-            $resources,
-            $ids,
-            [],
         );
     }
 }

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToProductListFacadeBridgeTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/Dependency/Facade/ProductListConditionalAvailabilityPageSearchToProductListFacadeBridgeTest.php
@@ -8,14 +8,8 @@ use Spryker\Zed\ProductList\Business\ProductListFacadeInterface;
 
 class ProductListConditionalAvailabilityPageSearchToProductListFacadeBridgeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\Dependency\Facade\ProductListConditionalAvailabilityPageSearchToProductListFacadeBridge
-     */
     protected ProductListConditionalAvailabilityPageSearchToProductListFacadeBridge $bridge;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\ProductList\Business\ProductListFacadeInterface
-     */
     protected MockObject|ProductListFacadeInterface $facadeMock;
 
     /**

--- a/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchDependencyProviderTest.php
+++ b/bundles/product-list-conditional-availability-page-search/tests/FondOfImpala/Zed/ProductListConditionalAvailabilityPageSearch/ProductListConditionalAvailabilityPageSearchDependencyProviderTest.php
@@ -8,14 +8,8 @@ use Spryker\Zed\Kernel\Container;
 
 class ProductListConditionalAvailabilityPageSearchDependencyProviderTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ProductListConditionalAvailabilityPageSearch\ProductListConditionalAvailabilityPageSearchDependencyProvider
-     */
     protected MockObject|ProductListConditionalAvailabilityPageSearchDependencyProvider $dependencyProvider;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Kernel\Container
-     */
     protected MockObject|Container $containerMock;
 
     /**

--- a/dandelion.json
+++ b/dandelion.json
@@ -301,7 +301,7 @@
     },
     "product-list-conditional-availability-page-search": {
       "path": "bundles/product-list-conditional-availability-page-search",
-      "version": "1.2.0"
+      "version": "1.3.0"
     },
     "product-list-price-product-price-list-page-search": {
       "path": "bundles/product-list-price-product-price-list-page-search",


### PR DESCRIPTION
- directly refresh conditional availability periods after CUD relationships between product list and product concrete (sync)
  - use new facade method `publishByConditionalAvailabilityIds` from `fond-of-impala/conditional-availability-page-search`
- add product list reader with caching mechanism
- add rector fixes