### PR TITLE
fix: replace duplicated event name in subscriber

### DIFF
--- a/bundles/product-group-hash/src/FondOfImpala/Zed/ProductGroupHash/Communication/Plugin/Event/Subscriber/ProductGroupHashEventSubscriber.php
+++ b/bundles/product-group-hash/src/FondOfImpala/Zed/ProductGroupHash/Communication/Plugin/Event/Subscriber/ProductGroupHashEventSubscriber.php
@@ -23,7 +23,7 @@ class ProductGroupHashEventSubscriber extends AbstractPlugin implements EventSub
         );
 
         return $eventCollection->addListener(
-            ProductEvents::PRODUCT_ABSTRACT_BEFORE_CREATE,
+            ProductEvents::PRODUCT_ABSTRACT_BEFORE_UPDATE,
             new ProductGroupHashListener(),
         );
     }

--- a/bundles/product-group-hash/tests/FondOfImpala/Zed/ProductGroupHash/Communication/Plugin/Event/Subscriber/ProductGroupHashEventSubscriberTest.php
+++ b/bundles/product-group-hash/tests/FondOfImpala/Zed/ProductGroupHash/Communication/Plugin/Event/Subscriber/ProductGroupHashEventSubscriberTest.php
@@ -46,11 +46,11 @@ class ProductGroupHashEventSubscriberTest extends Unit
                     ?string $eventQueueName = null
                 ): LogicException|EventCollectionInterface => match (
                     [
-                    $eventName,
-                    get_class($eventHandler),
-                    $priority,
-                    $queuePoolName,
-                    $eventQueueName,
+                        $eventName,
+                        get_class($eventHandler),
+                        $priority,
+                        $queuePoolName,
+                        $eventQueueName,
                     ]
                 ) {
                     [


### PR DESCRIPTION
- use `ProductEvents::PRODUCT_ABSTRACT_BEFORE_UPDATE` for second `ProductEvents::PRODUCT_ABSTRACT_BEFORE_CREATE`