### PR TITLE
Bugfix: fix permission sync if no permission set was set before

### DIFF
--- a/bundles/company-type-role/composer.json
+++ b/bundles/company-type-role/composer.json
@@ -25,6 +25,7 @@
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",
+    "phpunit/phpunit": "<10",
     "spryker/code-sniffer": "*",
     "spryker-sdk/phpstan-spryker": "*"
   },

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Reader/CompanyRoleReaderInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Reader/CompanyRoleReaderInterface.php
@@ -14,11 +14,25 @@ interface CompanyRoleReaderInterface
     public function findSyncableCompanyRoles(): array;
 
     /**
+     * @return array<\Generated\Shared\Transfer\SyncableCompanyRoleTransfer>
+     */
+    public function findEmptyPermissionSetSyncableCompanyRoles(): array;
+
+    /**
      * @param \Generated\Shared\Transfer\PermissionSetTransfer $permissionSetTransfer
      *
      * @return \Generated\Shared\Transfer\SyncableCompanyRoleTransfer|null
      */
     public function findSyncableCompanyRoleByPermissionSet(
+        PermissionSetTransfer $permissionSetTransfer
+    ): ?SyncableCompanyRoleTransfer;
+
+    /**
+     * @param \Generated\Shared\Transfer\PermissionSetTransfer $permissionSetTransfer
+     *
+     * @return \Generated\Shared\Transfer\SyncableCompanyRoleTransfer|null
+     */
+    public function findMissingSyncableCompanyRoleByPermissionSet(
         PermissionSetTransfer $permissionSetTransfer
     ): ?SyncableCompanyRoleTransfer;
 

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Synchronizer/PermissionSynchronizer.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Synchronizer/PermissionSynchronizer.php
@@ -34,6 +34,7 @@ class PermissionSynchronizer implements PermissionSynchronizerInterface
 
     /**
      * @param array<\Generated\Shared\Transfer\SyncableCompanyRoleTransfer> $syncableCompanyRoles
+     *
      * @return void
      */
     protected function handleSyncableCompanyRoles(array $syncableCompanyRoles): void

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Synchronizer/PermissionSynchronizer.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Business/Synchronizer/PermissionSynchronizer.php
@@ -28,8 +28,16 @@ class PermissionSynchronizer implements PermissionSynchronizerInterface
      */
     public function sync(): void
     {
-        $syncableCompanyRoles = $this->companyRoleReader->findSyncableCompanyRoles();
+        $this->handleSyncableCompanyRoles($this->companyRoleReader->findEmptyPermissionSetSyncableCompanyRoles());
+        $this->handleSyncableCompanyRoles($this->companyRoleReader->findSyncableCompanyRoles());
+    }
 
+    /**
+     * @param array<\Generated\Shared\Transfer\SyncableCompanyRoleTransfer> $syncableCompanyRoles
+     * @return void
+     */
+    protected function handleSyncableCompanyRoles(array $syncableCompanyRoles): void
+    {
         foreach ($syncableCompanyRoles as $syncableCompanyRole) {
             $syncableCompanyRoleIds = $syncableCompanyRole->getIds();
 

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
@@ -73,12 +73,12 @@ class CompanyTypeRoleRepository extends AbstractRepository implements CompanyTyp
         // @phpstan-ignore-next-line
         return SpyCompanyRoleQuery::create()
             ->useSpyCompanyRoleToPermissionQuery()
-                ->innerJoinPermission()
+            ->innerJoinPermission()
             ->endUse()
             ->useCompanyQuery()
-                ->useFoiCompanyTypeQuery()
-                    ->filterByName($companyTypeName)
-                ->endUse()
+            ->useFoiCompanyTypeQuery()
+            ->filterByName($companyTypeName)
+            ->endUse()
             ->endUse()
             ->filterByName($companyRoleName)
             ->orderBy(SpyCompanyRoleTableMap::COL_ID_COMPANY_ROLE)
@@ -99,21 +99,21 @@ class CompanyTypeRoleRepository extends AbstractRepository implements CompanyTyp
         string $companyTypeName,
         string $companyRoleName
     ): array {
-
         $query = SpyCompanyRoleQuery::create()
             ->useSpyCompanyRoleToPermissionQuery(null, 'LEFT OUTER JOIN')->filterByIdCompanyRoleToPermission(null, Criteria::ISNULL)
-                ->joinPermission(null, 'LEFT OUTER JOIN')
+            ->joinPermission(null, 'LEFT OUTER JOIN')
             ->endUse()
             ->useCompanyQuery()
-                ->useFoiCompanyTypeQuery()
-                    ->filterByName($companyTypeName)
-                ->endUse()
+            ->useFoiCompanyTypeQuery()
+            ->filterByName($companyTypeName)
+            ->endUse()
             ->endUse()
             ->filterByName($companyRoleName)
             ->orderBy(SpyCompanyRoleTableMap::COL_ID_COMPANY_ROLE)
             ->select([SpyCompanyRoleTableMap::COL_ID_COMPANY_ROLE])
             ->groupByIdCompanyRole();
 
+        // @phpstan-ignore-next-line
         return $query
             ->find()
             ->toArray();
@@ -165,7 +165,7 @@ class CompanyTypeRoleRepository extends AbstractRepository implements CompanyTyp
     ): CompanyUserCollectionTransfer {
         $spyCompanyUsers = SpyCompanyUserQuery::create()
             ->useSpyCompanyRoleToCompanyUserQuery()
-                ->filterByFkCompanyRole($companyRoleId)
+            ->filterByFkCompanyRole($companyRoleId)
             ->endUse()
             ->find();
 

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepository.php
@@ -90,6 +90,36 @@ class CompanyTypeRoleRepository extends AbstractRepository implements CompanyTyp
     }
 
     /**
+     * @param string $companyTypeName
+     * @param string $companyRoleName
+     *
+     * @return array<int>
+     */
+    public function findSyncableCompanyRoleIdsWithEmptyPermissionSet(
+        string $companyTypeName,
+        string $companyRoleName
+    ): array {
+
+        $query = SpyCompanyRoleQuery::create()
+            ->useSpyCompanyRoleToPermissionQuery(null, 'LEFT OUTER JOIN')->filterByIdCompanyRoleToPermission(null, Criteria::ISNULL)
+                ->joinPermission(null, 'LEFT OUTER JOIN')
+            ->endUse()
+            ->useCompanyQuery()
+                ->useFoiCompanyTypeQuery()
+                    ->filterByName($companyTypeName)
+                ->endUse()
+            ->endUse()
+            ->filterByName($companyRoleName)
+            ->orderBy(SpyCompanyRoleTableMap::COL_ID_COMPANY_ROLE)
+            ->select([SpyCompanyRoleTableMap::COL_ID_COMPANY_ROLE])
+            ->groupByIdCompanyRole();
+
+        return $query
+            ->find()
+            ->toArray();
+    }
+
+    /**
      * @param array<int> $companyRoleIds
      *
      * @return \Generated\Shared\Transfer\CompanyRoleCollectionTransfer

--- a/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepositoryInterface.php
+++ b/bundles/company-type-role/src/FondOfImpala/Zed/CompanyTypeRole/Persistence/CompanyTypeRoleRepositoryInterface.php
@@ -30,6 +30,17 @@ interface CompanyTypeRoleRepositoryInterface
     ): array;
 
     /**
+     * @param string $companyTypeName
+     * @param string $companyRoleName
+     *
+     * @return array<int>
+     */
+    public function findSyncableCompanyRoleIdsWithEmptyPermissionSet(
+        string $companyTypeName,
+        string $companyRoleName
+    ): array;
+
+    /**
      * @param array<int> $companyRoleIds
      *
      * @return \Generated\Shared\Transfer\CompanyRoleCollectionTransfer

--- a/dandelion.json
+++ b/dandelion.json
@@ -105,7 +105,7 @@
     },
     "company-type-role": {
       "path": "bundles/company-type-role",
-      "version": "1.3.1"
+      "version": "1.3.2"
     },
     "company-user-carts-rest-api": {
       "path": "bundles/company-user-carts-rest-api",


### PR DESCRIPTION
fix the bug when a new role appears and no permission set is available that those cases are not ignored anymore.