### PR TITLE
chore: allow also phpunit/phpunit version >= 10

### DIFF
--- a/bundles/erp-order-cancellation-api/composer.json
+++ b/bundles/erp-order-cancellation-api/composer.json
@@ -17,7 +17,6 @@
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",
-    "phpunit/phpunit": "<10",
     "spryker/code-sniffer": "*",
     "spryker-sdk/phpstan-spryker": "*"
   },

--- a/bundles/erp-order-cancellation-api/src/FondOfImpala/Zed/ErpOrderCancellationApi/Business/Model/ErpOrderCancellationApi.php
+++ b/bundles/erp-order-cancellation-api/src/FondOfImpala/Zed/ErpOrderCancellationApi/Business/Model/ErpOrderCancellationApi.php
@@ -2,6 +2,7 @@
 
 namespace FondOfImpala\Zed\ErpOrderCancellationApi\Business\Model;
 
+use Exception;
 use FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade\ErpOrderCancellationApiToApiFacadeInterface;
 use FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade\ErpOrderCancellationApiToErpOrderCancellationFacadeInterface;
 use FondOfImpala\Zed\ErpOrderCancellationApi\Persistence\ErpOrderCancellationApiRepositoryInterface;
@@ -11,7 +12,6 @@ use Generated\Shared\Transfer\ApiItemTransfer;
 use Generated\Shared\Transfer\ApiRequestTransfer;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
 use Orm\Zed\ErpOrderCancellation\Persistence\Map\FoiErpOrderCancellationTableMap;
-use PHPUnit\Util\Exception;
 use Spryker\Zed\Api\ApiConfig;
 use Spryker\Zed\Api\Business\Exception\EntityNotFoundException;
 use Spryker\Zed\Api\Business\Exception\EntityNotSavedException;
@@ -241,7 +241,7 @@ class ErpOrderCancellationApi implements ErpOrderCancellationApiInterface
     /**
      * @param string $state
      *
-     * @throws \PHPUnit\Util\Exception
+     * @throws \Exception
      *
      * @return int
      */

--- a/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Business/Model/ErpOrderCancellationApiTest.php
+++ b/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Business/Model/ErpOrderCancellationApiTest.php
@@ -3,7 +3,6 @@
 namespace FondOfImpala\Zed\ErpOrderCancellationApi\Business\Model;
 
 use Codeception\Test\Unit;
-use Exception;
 use FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade\ErpOrderCancellationApiToApiFacadeInterface;
 use FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade\ErpOrderCancellationApiToErpOrderCancellationFacadeInterface;
 use FondOfImpala\Zed\ErpOrderCancellationApi\Persistence\ErpOrderCancellationApiRepositoryInterface;
@@ -17,6 +16,7 @@ use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
 use Spryker\Zed\Api\Business\Exception\EntityNotFoundException;
 use Spryker\Zed\Api\Business\Exception\EntityNotSavedException;
+use Throwable;
 
 class ErpOrderCancellationApiTest extends Unit
 {
@@ -144,34 +144,34 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $idErpOrderCancellation = 1;
 
-        $this->apiDataTransferMock->expects(static::atLeastOnce())
+        $this->apiDataTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn([]);
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('createErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationResponseTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getIsSuccessful')
             ->willReturn(true);
 
-        $this->erpOrderCancellationTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationTransferMock->expects($this->atLeastOnce())
             ->method('getIdErpOrderCancellation')
             ->willReturn($idErpOrderCancellation);
 
-        $this->erpOrderCancellationApiToApiFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToApiFacadeMock->expects($this->atLeastOnce())
             ->method('createApiItem')
             ->with($this->erpOrderCancellationTransferMock, (string)$idErpOrderCancellation)
             ->willReturn($this->apiItemTransferMock);
 
         $responseTransfer = $this->model->create($this->apiDataTransferMock);
 
-        static::assertEquals($this->apiItemTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiItemTransferMock, $responseTransfer);
     }
 
     /**
@@ -179,23 +179,23 @@ class ErpOrderCancellationApiTest extends Unit
      */
     public function testCreateWithException(): void
     {
-        $this->apiDataTransferMock->expects(static::atLeastOnce())
+        $this->apiDataTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn([]);
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('createErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationResponseTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getIsSuccessful')
             ->willReturn(false);
 
-        static::expectException(EntityNotSavedException::class);
+        $this->expectException(EntityNotSavedException::class);
 
         $this->model->create($this->apiDataTransferMock);
     }
@@ -207,39 +207,39 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $idErpOrderCancellation = 1;
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('findErpOrderCancellationByIdErpOrderCancellation')
             ->with($idErpOrderCancellation)
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->apiDataTransferMock->expects(static::atLeastOnce())
+        $this->apiDataTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn([]);
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('updateErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationResponseTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getIsSuccessful')
             ->willReturn(true);
 
-        $this->erpOrderCancellationTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationTransferMock->expects($this->atLeastOnce())
             ->method('getIdErpOrderCancellation')
             ->willReturn($idErpOrderCancellation);
 
-        $this->erpOrderCancellationApiToApiFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToApiFacadeMock->expects($this->atLeastOnce())
             ->method('createApiItem')
             ->with($this->erpOrderCancellationTransferMock, (string)$idErpOrderCancellation)
             ->willReturn($this->apiItemTransferMock);
 
         $responseTransfer = $this->model->update($idErpOrderCancellation, $this->apiDataTransferMock);
 
-        static::assertEquals($this->apiItemTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiItemTransferMock, $responseTransfer);
     }
 
     /**
@@ -249,28 +249,28 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $idErpOrderCancellation = 1;
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('findErpOrderCancellationByIdErpOrderCancellation')
             ->with($idErpOrderCancellation)
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->apiDataTransferMock->expects(static::atLeastOnce())
+        $this->apiDataTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn([]);
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('updateErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationResponseTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->erpOrderCancellationResponseTransferMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationResponseTransferMock->expects($this->atLeastOnce())
             ->method('getIsSuccessful')
             ->willReturn(false);
 
-        static::expectException(EntityNotSavedException::class);
+        $this->expectException(EntityNotSavedException::class);
 
         $this->model->update($idErpOrderCancellation, $this->apiDataTransferMock);
     }
@@ -282,19 +282,19 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $idErpOrderCancellation = 1;
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('findErpOrderCancellationByIdErpOrderCancellation')
             ->with($idErpOrderCancellation)
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->erpOrderCancellationApiToApiFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToApiFacadeMock->expects($this->atLeastOnce())
             ->method('createApiItem')
             ->with($this->erpOrderCancellationTransferMock, (string)$idErpOrderCancellation)
             ->willReturn($this->apiItemTransferMock);
 
         $responseTransfer = $this->model->get($idErpOrderCancellation);
 
-        static::assertEquals($this->apiItemTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiItemTransferMock, $responseTransfer);
     }
 
     /**
@@ -304,12 +304,12 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $idErpOrderCancellation = 1;
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('findErpOrderCancellationByIdErpOrderCancellation')
             ->with($idErpOrderCancellation)
             ->willReturn(null);
 
-        static::expectException(EntityNotFoundException::class);
+        $this->expectException(EntityNotFoundException::class);
 
         $this->model->get($idErpOrderCancellation);
     }
@@ -334,47 +334,47 @@ class ErpOrderCancellationApiTest extends Unit
             ],
         ];
 
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('getFilter')
             ->willReturn($this->apiFilterTransferMock);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('getCriteriaJson')
             ->willReturn($criteriaJson);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('setCriteriaJson');
 
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('setFilter')
             ->with($this->apiFilterTransferMock)
             ->willReturn($this->apiRequestTransferMock);
 
-        $this->erpOrderCancellationApiRepositoryMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiRepositoryMock->expects($this->atLeastOnce())
             ->method('find')
             ->with($this->apiRequestTransferMock)
             ->willReturn($this->apiCollectionTransferMock);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn($apiCollectionData);
 
-         $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+         $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
              ->method('findErpOrderCancellationByIdErpOrderCancellation')
              ->with($idErpOrderCancellation)
              ->willReturn($this->erpOrderCancellationTransferMock);
 
-         $this->erpOrderCancellationTransferMock->expects(static::atLeastOnce())
+         $this->erpOrderCancellationTransferMock->expects($this->atLeastOnce())
              ->method('toArray')
              ->willReturn([]);
 
-         $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+         $this->apiCollectionTransferMock->expects($this->atLeastOnce())
              ->method('setData')
              ->willReturn($this->apiCollectionTransferMock);
 
         $responseTransfer = $this->model->find($this->apiRequestTransferMock);
 
-        static::assertEquals($this->apiCollectionTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiCollectionTransferMock, $responseTransfer);
     }
 
     /**
@@ -390,15 +390,15 @@ class ErpOrderCancellationApiTest extends Unit
             }
         ]}';
 
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('getFilter')
             ->willReturn($this->apiFilterTransferMock);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('getCriteriaJson')
             ->willReturn($criteriaJson);
 
-        static::expectException(Exception::class);
+        $this->expectException(Throwable::class);
 
         $this->model->find($this->apiRequestTransferMock);
     }
@@ -408,30 +408,30 @@ class ErpOrderCancellationApiTest extends Unit
      */
     public function testFindWithNoCriteriaJson(): void
     {
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('getFilter')
             ->willReturn($this->apiFilterTransferMock);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('getCriteriaJson')
             ->willReturn(null);
 
-        $this->erpOrderCancellationApiRepositoryMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiRepositoryMock->expects($this->atLeastOnce())
             ->method('find')
             ->with($this->apiRequestTransferMock)
             ->willReturn($this->apiCollectionTransferMock);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn([]);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('setData')
             ->willReturn($this->apiCollectionTransferMock);
 
         $responseTransfer = $this->model->find($this->apiRequestTransferMock);
 
-        static::assertEquals($this->apiCollectionTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiCollectionTransferMock, $responseTransfer);
     }
 
     /**
@@ -441,30 +441,30 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $criteriaJson = '{}';
 
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('getFilter')
             ->willReturn($this->apiFilterTransferMock);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('getCriteriaJson')
             ->willReturn($criteriaJson);
 
-        $this->erpOrderCancellationApiRepositoryMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiRepositoryMock->expects($this->atLeastOnce())
             ->method('find')
             ->with($this->apiRequestTransferMock)
             ->willReturn($this->apiCollectionTransferMock);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn([]);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('setData')
             ->willReturn($this->apiCollectionTransferMock);
 
         $responseTransfer = $this->model->find($this->apiRequestTransferMock);
 
-        static::assertEquals($this->apiCollectionTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiCollectionTransferMock, $responseTransfer);
     }
 
     /**
@@ -486,43 +486,43 @@ class ErpOrderCancellationApiTest extends Unit
             ],
         ];
 
-        $this->erpOrderCancellationApiRepositoryMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiRepositoryMock->expects($this->atLeastOnce())
             ->method('find')
             ->with($this->apiRequestTransferMock)
             ->willReturn($this->apiCollectionTransferMock);
 
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('getFilter')
             ->willReturn($this->apiFilterTransferMock);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('getCriteriaJson')
             ->willReturn($criteriaJson);
 
-        $this->apiFilterTransferMock->expects(static::atLeastOnce())
+        $this->apiFilterTransferMock->expects($this->atLeastOnce())
             ->method('setCriteriaJson');
 
-        $this->apiRequestTransferMock->expects(static::atLeastOnce())
+        $this->apiRequestTransferMock->expects($this->atLeastOnce())
             ->method('setFilter')
             ->with($this->apiFilterTransferMock)
             ->willReturn($this->apiRequestTransferMock);
 
-        $this->erpOrderCancellationApiRepositoryMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiRepositoryMock->expects($this->atLeastOnce())
             ->method('find')
             ->with($this->apiRequestTransferMock)
             ->willReturn($this->apiCollectionTransferMock);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('getData')
             ->willReturn($apiCollectionData);
 
-        $this->apiCollectionTransferMock->expects(static::atLeastOnce())
+        $this->apiCollectionTransferMock->expects($this->atLeastOnce())
             ->method('setData')
             ->willReturn($this->apiCollectionTransferMock);
 
         $responseTransfer = $this->model->find($this->apiRequestTransferMock);
 
-        static::assertEquals($this->apiCollectionTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiCollectionTransferMock, $responseTransfer);
     }
 
     /**
@@ -532,22 +532,22 @@ class ErpOrderCancellationApiTest extends Unit
     {
         $idErpOrderCancellation = 1;
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('findErpOrderCancellationByIdErpOrderCancellation')
             ->with($idErpOrderCancellation)
             ->willReturn($this->erpOrderCancellationTransferMock);
 
-        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToErpOrderCancellationFacadeMock->expects($this->atLeastOnce())
             ->method('deleteErpOrderCancellationByIdErpOrderCancellation')
             ->with($idErpOrderCancellation);
 
-        $this->erpOrderCancellationApiToApiFacadeMock->expects(static::atLeastOnce())
+        $this->erpOrderCancellationApiToApiFacadeMock->expects($this->atLeastOnce())
             ->method('createApiItem')
             ->with(null, (string)$idErpOrderCancellation)
             ->willReturn($this->apiItemTransferMock);
 
         $responseTransfer = $this->model->delete($idErpOrderCancellation);
 
-        static::assertEquals($this->apiItemTransferMock, $responseTransfer);
+        $this->assertEquals($this->apiItemTransferMock, $responseTransfer);
     }
 }

--- a/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Dependency/Facade/ErpOrderCancellationApiToApiFacadeBridgeTest.php
+++ b/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Dependency/Facade/ErpOrderCancellationApiToApiFacadeBridgeTest.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade;
 use Codeception\Test\Unit;
 use Generated\Shared\Transfer\ApiCollectionTransfer;
 use Generated\Shared\Transfer\ApiItemTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 use Spryker\Shared\Kernel\Transfer\AbstractTransfer;
 use Spryker\Zed\Api\Business\ApiFacadeInterface;
 
@@ -19,6 +20,11 @@ class ErpOrderCancellationApiToApiFacadeBridgeTest extends Unit
      * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ApiItemTransfer
      */
     protected MockObject|ApiItemTransfer $apiItemTransferMock;
+
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Shared\Kernel\Transfer\AbstractTransfer
+     */
+    protected MockObject|AbstractTransfer $abstractTransferMock;
 
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\Spryker\Zed\Api\Business\ApiFacadeInterface

--- a/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Dependency/Facade/ErpOrderCancellationApiToErpOrderCancellationFacadeBridgeTest.php
+++ b/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Dependency/Facade/ErpOrderCancellationApiToErpOrderCancellationFacadeBridgeTest.php
@@ -6,6 +6,7 @@ use Codeception\Test\Unit;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\ErpOrderCancellationFacadeInterface;
 use Generated\Shared\Transfer\ErpOrderCancellationResponseTransfer;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ErpOrderCancellationApiToErpOrderCancellationFacadeBridgeTest extends Unit
 {
@@ -25,7 +26,7 @@ class ErpOrderCancellationApiToErpOrderCancellationFacadeBridgeTest extends Unit
     protected MockObject|ErpOrderCancellationTransfer $erpOrderCancellationTransferMock;
 
     /**
-     * @var \FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade/ErpOrderCancellationApiToErpOrderCancellationFacadeBridge
+     * @var \FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\Facade\ErpOrderCancellationApiToErpOrderCancellationFacadeBridge
      */
     protected ErpOrderCancellationApiToErpOrderCancellationFacadeBridge $bridge;
 

--- a/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Dependency/QueryContainer/ErpOrderCancellationApiToApiQueryBuilderQueryContainerBridgeTest.php
+++ b/bundles/erp-order-cancellation-api/tests/FondOfImpala/Zed/ErpOrderCancellationApi/Dependency/QueryContainer/ErpOrderCancellationApiToApiQueryBuilderQueryContainerBridgeTest.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\ErpOrderCancellationApi\Dependency\QueryContainer;
 use Codeception\Test\Unit;
 use Generated\Shared\Transfer\ApiQueryBuilderQueryTransfer;
 use Generated\Shared\Transfer\PropelQueryBuilderCriteriaTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Spryker\Zed\ApiQueryBuilder\Persistence\ApiQueryBuilderQueryContainerInterface;
 

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Business/ErpOrderCancellationMailConnectorBusinessFactoryTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Business/ErpOrderCancellationMailConnectorBusinessFactoryTest.php
@@ -96,9 +96,12 @@ class ErpOrderCancellationMailConnectorBusinessFactoryTest extends Unit
             ->method('get')
             ->willReturnCallback(
                 static function (string $key) use ($self, $callCount) {
+                    /** @phpstan-ignore-next-line */
                     if (method_exists($callCount, 'getInvocationCount')) {
+                        /** @phpstan-ignore-next-line */
                         $count = $callCount->getInvocationCount();
                     } else {
+                        /** @phpstan-ignore-next-line */
                         $count = $callCount->numberOfInvocations();
                     }
 

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/ErpOrderCancellation/NotifyApprovedErpOrderCancellationPostTransactionPluginTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/ErpOrderCancellation/NotifyApprovedErpOrderCancellationPostTransactionPluginTest.php
@@ -94,7 +94,6 @@ class NotifyApprovedErpOrderCancellationPostTransactionPluginTest extends Unit
      */
     public function testPostTransactionDoNothing(): void
     {
-        $self = $this;
         $this->erpOrderCancellationResponseTransferMock->expects(static::once())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/ErpOrderCancellation/NotifyNewErpOrderCancellationPostTransactionPluginTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/ErpOrderCancellation/NotifyNewErpOrderCancellationPostTransactionPluginTest.php
@@ -94,7 +94,6 @@ class NotifyNewErpOrderCancellationPostTransactionPluginTest extends Unit
      */
     public function testPostTransactionDoNothing(): void
     {
-        $self = $this;
         $this->erpOrderCancellationResponseTransferMock->expects(static::once())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/ErpOrderCancellation/NotifyRejectedErpOrderCancellationPostTransactionPluginTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/ErpOrderCancellation/NotifyRejectedErpOrderCancellationPostTransactionPluginTest.php
@@ -94,7 +94,6 @@ class NotifyRejectedErpOrderCancellationPostTransactionPluginTest extends Unit
      */
     public function testPostTransactionDoNothing(): void
     {
-        $self = $this;
         $this->erpOrderCancellationResponseTransferMock->expects(static::once())
             ->method('getErpOrderCancellation')
             ->willReturn($this->erpOrderCancellationTransferMock);

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/Mail/NotifyApprovedErpOrderCancellationMailTypePluginTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/Mail/NotifyApprovedErpOrderCancellationMailTypePluginTest.php
@@ -177,9 +177,12 @@ class NotifyApprovedErpOrderCancellationMailTypePluginTest extends Unit
         $callCount = $this->exactly(2);
         $this->mailTransferMock->expects($callCount)
             ->method('addRecipientBcc')->willReturnCallback(static function (MailRecipientTransfer $mailRecipientTransfer) use ($callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/Mail/NotifyReadyErpOrderCancellationMailTypePluginTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/Mail/NotifyReadyErpOrderCancellationMailTypePluginTest.php
@@ -177,9 +177,12 @@ class NotifyReadyErpOrderCancellationMailTypePluginTest extends Unit
         $callCount = $this->exactly(2);
         $this->mailTransferMock->expects($callCount)
             ->method('addRecipientBcc')->willReturnCallback(static function (MailRecipientTransfer $mailRecipientTransfer) use ($callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/Mail/NotifyRejectedErpOrderCancellationMailTypePluginTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/Communication/Plugin/Mail/NotifyRejectedErpOrderCancellationMailTypePluginTest.php
@@ -177,9 +177,12 @@ class NotifyRejectedErpOrderCancellationMailTypePluginTest extends Unit
         $callCount = $this->exactly(2);
         $this->mailTransferMock->expects($callCount)
             ->method('addRecipientBcc')->willReturnCallback(static function (MailRecipientTransfer $mailRecipientTransfer) use ($callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 

--- a/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/ErpOrderCancellationMailConnectorDependencyProviderTest.php
+++ b/bundles/erp-order-cancellation-mail-connector/tests/FondOfImpala/Zed/ErpOrderCancellationMailConnector/ErpOrderCancellationMailConnectorDependencyProviderTest.php
@@ -37,9 +37,12 @@ class ErpOrderCancellationMailConnectorDependencyProviderTest extends Unit
     {
         $containerMock = $this->getMockBuilder(Container::class);
 
+        /** @phpstan-ignore-next-line */
         if (method_exists($containerMock, 'setMethodsExcept')) {
+            /** @phpstan-ignore-next-line */
             $containerMock->setMethodsExcept(['factory', 'set', 'offsetSet', 'get', 'offsetGet']);
         } else {
+            /** @phpstan-ignore-next-line */
             $containerMock->onlyMethods(['getLocator'])->enableOriginalClone();
         }
 

--- a/bundles/erp-order-cancellation-rest-api/composer.json
+++ b/bundles/erp-order-cancellation-rest-api/composer.json
@@ -26,7 +26,6 @@
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",
-    "phpunit/phpunit": "<10",
     "spryker/code-sniffer": "*",
     "spryker-sdk/phpstan-spryker": "*"
   },

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Business/Model/Expander/ErpOrderCancellationExpanderTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Business/Model/Expander/ErpOrderCancellationExpanderTest.php
@@ -31,11 +31,6 @@ class ErpOrderCancellationExpanderTest extends Unit
     protected MockObject|ErpOrderCancellationExpanderPluginInterface $erpOrderCancellationExpanderPlugin2Mock;
 
     /**
-     * @var array<\FondOfImpala\Zed\ErpOrderCancellationRestApiExtension\Dependency\Plugin\ErpOrderCancellationExpanderPluginInterface>
-     */
-    protected array $erpOrderCancellationExpanderPluginMocks = [];
-
-    /**
      * @var \FondOfImpala\Zed\ErpOrderCancellationRestApi\Business\Model\Expander\ErpOrderCancellationExpander
      */
     protected ErpOrderCancellationExpander $expander;
@@ -61,12 +56,11 @@ class ErpOrderCancellationExpanderTest extends Unit
             ->disableOriginalConstructor()
             ->getMock();
 
-        $plugins = [
+        /** @phpstan-ignore-next-line */
+        $this->expander = new ErpOrderCancellationExpander([
             $this->erpOrderCancellationExpanderPluginMock,
             $this->erpOrderCancellationExpanderPlugin2Mock,
-        ];
-
-        $this->expander = new ErpOrderCancellationExpander($plugins);
+        ]);
     }
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Business/Model/Permission/PermissionCheckerTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Business/Model/Permission/PermissionCheckerTest.php
@@ -6,7 +6,6 @@ use Codeception\Test\Unit;
 use FondOfImpala\Zed\ErpOrderCancellationRestApiExtension\Dependency\Plugin\ErpOrderCancellationPermissionPluginInterface;
 use Generated\Shared\Transfer\CompanyUserTransfer;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
-use Generated\Shared\Transfer\RestErpOrderCancellationRequestTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
 
 class PermissionCheckerTest extends Unit
@@ -46,10 +45,6 @@ class PermissionCheckerTest extends Unit
      */
     protected function _before(): void
     {
-        $this->restErpOrderCancellationRequestTransferMock = $this->getMockBuilder(RestErpOrderCancellationRequestTransfer::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $this->erpOrderCancellationTransferMock = $this->getMockBuilder(ErpOrderCancellationTransfer::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/QueryExpander/DebitorNumberQueryExpanderPluginTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/QueryExpander/DebitorNumberQueryExpanderPluginTest.php
@@ -9,19 +9,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class DebitorNumberQueryExpanderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ErpOrderCancellation\Persistence\FoiErpOrderCancellationQuery
-     */
-    protected MockObject|FoiErpOrderCancellationQuery $foiErpOrderCancellationQuery;
+    protected MockObject|FoiErpOrderCancellationQuery $foiErpOrderCancellationQueryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
-    protected MockObject|RestErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
+    protected MockObject|ErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationRestApi\Communication\Plugin\QueryExpander\DebitorNumberQueryExpanderPlugin
-     */
     protected DebitorNumberQueryExpanderPlugin $plugin;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/QueryExpander/ExternalReferenceQueryExpanderPluginTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/QueryExpander/ExternalReferenceQueryExpanderPluginTest.php
@@ -9,19 +9,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ExternalReferenceQueryExpanderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ErpOrderCancellation\Persistence\FoiErpOrderCancellationQuery
-     */
-    protected MockObject|FoiErpOrderCancellationQuery $foiErpOrderCancellationQuery;
+    protected MockObject|FoiErpOrderCancellationQuery $foiErpOrderCancellationQueryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
-    protected MockObject|RestErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
+    protected MockObject|ErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationRestApi\Communication\Plugin\QueryExpander\ExternalReferenceQueryExpanderPlugin
-     */
     protected ExternalReferenceQueryExpanderPlugin $plugin;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/QueryExpander/ReferenceQueryExpanderPluginTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/QueryExpander/ReferenceQueryExpanderPluginTest.php
@@ -9,19 +9,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ReferenceQueryExpanderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Orm\Zed\ErpOrderCancellation\Persistence\FoiErpOrderCancellationQuery
-     */
-    protected MockObject|FoiErpOrderCancellationQuery $foiErpOrderCancellationQuery;
+    protected MockObject|FoiErpOrderCancellationQuery $foiErpOrderCancellationQueryMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
-    protected MockObject|RestErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
+    protected MockObject|ErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationRestApi\Communication\Plugin\QueryExpander\ReferenceQueryExpanderPlugin
-     */
     protected ReferenceQueryExpanderPlugin $plugin;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/RestFilterExpander/DebitorNumberRestFilterToFilterMapperExpanderPluginTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/RestFilterExpander/DebitorNumberRestFilterToFilterMapperExpanderPluginTest.php
@@ -9,19 +9,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class DebitorNumberRestFilterToFilterMapperExpanderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
     protected MockObject|RestErpOrderCancellationFilterTransfer $restErpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
-    protected MockObject|RestErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
+    protected MockObject|ErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationRestApi\Communication\Plugin\RestFilterExpander\DebitorNumberRestFilterToFilterMapperExpanderPlugin
-     */
     protected DebitorNumberRestFilterToFilterMapperExpanderPlugin $plugin;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/RestFilterExpander/ExternalReferenceRestFilterToFilterMapperExpanderPluginTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/RestFilterExpander/ExternalReferenceRestFilterToFilterMapperExpanderPluginTest.php
@@ -9,19 +9,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ExternalReferenceRestFilterToFilterMapperExpanderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
     protected MockObject|RestErpOrderCancellationFilterTransfer $restErpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
-    protected MockObject|RestErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
+    protected MockObject|ErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationRestApi\Communication\Plugin\RestFilterExpander\ExternalReferenceRestFilterToFilterMapperExpanderPlugin
-     */
     protected ExternalReferenceRestFilterToFilterMapperExpanderPlugin $plugin;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/RestFilterExpander/ReferenceRestFilterToFilterMapperExpanderPluginTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Communication/Plugin/RestFilterExpander/ReferenceRestFilterToFilterMapperExpanderPluginTest.php
@@ -9,19 +9,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 class ReferenceRestFilterToFilterMapperExpanderPluginTest extends Unit
 {
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
     protected MockObject|RestErpOrderCancellationFilterTransfer $restErpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\RestErpOrderCancellationFilterTransfer
-     */
-    protected MockObject|RestErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
+    protected MockObject|ErpOrderCancellationFilterTransfer $erpOrderCancellationFilterTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationRestApi\Communication\Plugin\RestFilterExpander\ReferenceRestFilterToFilterMapperExpanderPlugin
-     */
     protected ReferenceRestFilterToFilterMapperExpanderPlugin $plugin;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Dependency/Facade/ErpOrderCancellationRestApiToErpOrderCancellationFacadeBridgeTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Dependency/Facade/ErpOrderCancellationRestApiToErpOrderCancellationFacadeBridgeTest.php
@@ -6,27 +6,16 @@ use Codeception\Test\Unit;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\ErpOrderCancellationFacadeInterface;
 use Generated\Shared\Transfer\ErpOrderCancellationResponseTransfer;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ErpOrderCancellationRestApiToErpOrderCancellationFacadeBridgeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ErpOrderCancellationRestApi\Dependency\Facade\ErpOrderCancellationRestApiToErpOrderCancellationFacadeBridge
-     */
     protected ErpOrderCancellationRestApiToErpOrderCancellationFacadeBridge $bridge;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\Business\ErpOrderCancellationFacadeInterface
-     */
     protected MockObject|ErpOrderCancellationFacadeInterface $erpOrderCancellationFacadeMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ErpOrderCancellationTransfer
-     */
     protected MockObject|ErpOrderCancellationTransfer $erpOrderCancellationTransferMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ErpOrderCancellationResponseTransfer
-     */
     protected MockObject|ErpOrderCancellationResponseTransfer $erpOrderCancellationResponseTransferMock;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Dependency/Facade/ErpOrderCancellationRestApiToErpOrderFacadeBridgeTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/Dependency/Facade/ErpOrderCancellationRestApiToErpOrderFacadeBridgeTest.php
@@ -5,22 +5,14 @@ namespace FondOfImpala\Zed\ErpOrderCancellationRestApi\Dependency\Facade;
 use Codeception\Test\Unit;
 use FondOfOryx\Zed\ErpOrder\Business\ErpOrderFacadeInterface;
 use Generated\Shared\Transfer\ErpOrderTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ErpOrderCancellationRestApiToErpOrderFacadeBridgeTest extends Unit
 {
-    /**
-     * @var \FondOfImpala\Zed\ErpOrderCancellationRestApi\Dependency\Facade\ErpOrderCancellationRestApiToErpOrderFacadeBridge
-     */
     protected ErpOrderCancellationRestApiToErpOrderFacadeBridge $bridge;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfOryx\Zed\ErpOrder\Business\ErpOrderFacadeInterface
-     */
     protected MockObject|ErpOrderFacadeInterface $erpOrderFacadeMock;
 
-    /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\Generated\Shared\Transfer\ErpOrderTransfer
-     */
     protected MockObject|ErpOrderTransfer $erpOrderTransferMock;
 
     /**

--- a/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/ErpOrderCancellationRestApiDependencyProviderTest.php
+++ b/bundles/erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/ErpOrderCancellationRestApi/ErpOrderCancellationRestApiDependencyProviderTest.php
@@ -54,9 +54,18 @@ class ErpOrderCancellationRestApiDependencyProviderTest extends Unit
      */
     protected function _before(): void
     {
-        $this->containerMock = $this->getMockBuilder(Container::class)
-            ->setMethodsExcept(['factory', 'set', 'offsetSet', 'get', 'offsetGet'])
-            ->getMock();
+        $containerMock = $this->getMockBuilder(Container::class);
+
+        /* @phpstan-ignore-next-line */
+        if (method_exists($containerMock, 'setMethodsExcept')) {
+            /** @phpstan-ignore-next-line */
+            $containerMock->setMethodsExcept(['factory', 'set', 'offsetSet', 'get', 'offsetGet']);
+        } else {
+            /** @phpstan-ignore-next-line */
+            $containerMock->onlyMethods(['getLocator'])->enableOriginalClone();
+        }
+
+        $this->containerMock = $containerMock->getMock();
 
         $this->locatorMock = $this->getMockBuilder(Locator::class)
             ->disableOriginalConstructor()

--- a/bundles/erp-order-cancellation/composer.json
+++ b/bundles/erp-order-cancellation/composer.json
@@ -22,7 +22,6 @@
   },
   "require-dev": {
     "fond-of-codeception/spryker": "*",
-    "phpunit/phpunit": "<10",
     "spryker/code-sniffer": "*",
     "spryker-sdk/phpstan-spryker": "*"
   },

--- a/bundles/erp-order-cancellation/src/FondOfImpala/Zed/ErpOrderCancellation/Business/Handler/ErpOrderCancellationItemHandler.php
+++ b/bundles/erp-order-cancellation/src/FondOfImpala/Zed/ErpOrderCancellation/Business/Handler/ErpOrderCancellationItemHandler.php
@@ -80,6 +80,7 @@ class ErpOrderCancellationItemHandler implements ErpOrderCancellationItemHandler
         }
 
         foreach ($preparedItems[static::UNTOUCHED] as $data) {
+            /** @phpstan-ignore-next-line */
             if (is_array($data)) {
                 foreach ($data as $item) {
                     $collection->append($item);

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/ErpOrderCancellationBusinessFactoryTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/ErpOrderCancellationBusinessFactoryTest.php
@@ -4,6 +4,7 @@ namespace FondOfImpala\Zed\ErpOrderCancellation\Business;
 
 use ArrayObject;
 use Codeception\Test\Unit;
+use Exception;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\Handler\ErpOrderCancellationItemHandlerInterface;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Reader\ErpOrderCancellationItemReaderInterface;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Reader\ReaderInterface;
@@ -100,17 +101,43 @@ class ErpOrderCancellationBusinessFactoryTest extends Unit
      */
     public function testCreateErpOrderCancellationWriter(): void
     {
+        $self = $this;
         $this->containerMock->expects(static::atLeastOnce())
             ->method('has')
             ->willReturn(true);
 
-        $this->containerMock->expects(static::atLeastOnce())
+        $callCount = static::atLeastOnce();
+        $this->containerMock->expects($callCount)
             ->method('get')
-            ->withConsecutive(
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_PRE_SAVE],
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_SAVE],
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_TRANSACTION],
-            )->willReturnOnConsecutiveCalls(new ArrayObject(), new ArrayObject(), new ArrayObject());
+            ->willReturnCallback(
+                static function (string $key) use ($self, $callCount) {
+                    /** @phpstan-ignore-next-line */
+                    if (method_exists($callCount, 'getInvocationCount')) {
+                        /** @phpstan-ignore-next-line */
+                        $count = $callCount->getInvocationCount();
+                    } else {
+                        /** @phpstan-ignore-next-line */
+                        $count = $callCount->numberOfInvocations();
+                    }
+
+                    switch ($count) {
+                        case 1:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_PRE_SAVE, $key);
+
+                            return new ArrayObject();
+                        case 2:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_SAVE, $key);
+
+                            return new ArrayObject();
+                        case 3:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_TRANSACTION, $key);
+
+                            return new ArrayObject();
+                    }
+
+                    throw new Exception('Invalid key');
+                },
+            );
 
         static::assertInstanceOf(
             ErpOrderCancellationWriterInterface::class,
@@ -123,17 +150,43 @@ class ErpOrderCancellationBusinessFactoryTest extends Unit
      */
     public function testCreateErpOrderCancellationItemWriter(): void
     {
+        $self = $this;
         $this->containerMock->expects(static::atLeastOnce())
             ->method('has')
             ->willReturn(true);
 
-        $this->containerMock->expects(static::atLeastOnce())
+        $callCount = static::atLeastOnce();
+        $this->containerMock->expects($callCount)
             ->method('get')
-            ->withConsecutive(
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_PRE_SAVE],
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_POST_SAVE],
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_TRANSACTION],
-            )->willReturnOnConsecutiveCalls(new ArrayObject(), new ArrayObject(), new ArrayObject());
+            ->willReturnCallback(
+                static function (string $key) use ($self, $callCount) {
+                    /** @phpstan-ignore-next-line */
+                    if (method_exists($callCount, 'getInvocationCount')) {
+                        /** @phpstan-ignore-next-line */
+                        $count = $callCount->getInvocationCount();
+                    } else {
+                        /** @phpstan-ignore-next-line */
+                        $count = $callCount->numberOfInvocations();
+                    }
+
+                    switch ($count) {
+                        case 1:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_PRE_SAVE, $key);
+
+                            return new ArrayObject();
+                        case 2:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_POST_SAVE, $key);
+
+                            return new ArrayObject();
+                        case 3:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_TRANSACTION, $key);
+
+                            return new ArrayObject();
+                    }
+
+                    throw new Exception('Invalid key');
+                },
+            );
 
         static::assertInstanceOf(
             ErpOrderCancellationItemWriterInterface::class,
@@ -146,17 +199,43 @@ class ErpOrderCancellationBusinessFactoryTest extends Unit
      */
     public function testCreateErpOrderCancellationItemHandler(): void
     {
+        $self = $this;
         $this->containerMock->expects(static::atLeastOnce())
             ->method('has')
             ->willReturn(true);
 
-        $this->containerMock->expects(static::atLeastOnce())
+        $callCount = static::atLeastOnce();
+        $this->containerMock->expects($callCount)
             ->method('get')
-            ->withConsecutive(
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_PRE_SAVE],
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_POST_SAVE],
-                [ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_TRANSACTION],
-            )->willReturnOnConsecutiveCalls(new ArrayObject(), new ArrayObject(), new ArrayObject());
+            ->willReturnCallback(
+                static function (string $key) use ($self, $callCount) {
+                    /** @phpstan-ignore-next-line */
+                    if (method_exists($callCount, 'getInvocationCount')) {
+                        /** @phpstan-ignore-next-line */
+                        $count = $callCount->getInvocationCount();
+                    } else {
+                        /** @phpstan-ignore-next-line */
+                        $count = $callCount->numberOfInvocations();
+                    }
+
+                    switch ($count) {
+                        case 1:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_PRE_SAVE, $key);
+
+                            return new ArrayObject();
+                        case 2:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_ITEM_POST_SAVE, $key);
+
+                            return new ArrayObject();
+                        case 3:
+                            $self->assertEquals(ErpOrderCancellationDependencyProvider::PLUGIN_ERP_ORDER_CANCELLATION_POST_TRANSACTION, $key);
+
+                            return new ArrayObject();
+                    }
+
+                    throw new Exception('Invalid key');
+                },
+            );
 
         static::assertInstanceOf(
             ErpOrderCancellationItemHandlerInterface::class,

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/ErpOrderCancellationFacadeTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/ErpOrderCancellationFacadeTest.php
@@ -8,6 +8,7 @@ use FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Reader\ReaderInterface;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Writer\ErpOrderCancellationWriterInterface;
 use Generated\Shared\Transfer\ErpOrderCancellationResponseTransfer;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ErpOrderCancellationFacadeTest extends Unit
 {

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/Handler/ErpOrderCancellationItemHandlerTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/Handler/ErpOrderCancellationItemHandlerTest.php
@@ -6,6 +6,8 @@ use ArrayObject;
 use Codeception\Test\Unit;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Reader\ErpOrderCancellationItemReaderInterface;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Writer\ErpOrderCancellationItemWriterInterface;
+use FondOfImpala\Zed\ErpOrderCancellationExtension\Dependency\Plugin\ErpOrderCancellationItemPostSavePluginInterface;
+use FondOfImpala\Zed\ErpOrderCancellationExtension\Dependency\Plugin\ErpOrderCancellationItemPreSavePluginInterface;
 use Generated\Shared\Transfer\ErpOrderCancellationItemTransfer;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -13,12 +15,12 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ErpOrderCancellationItemHandlerTest extends Unit
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Reader\ErpOrderCancellationItemReaderInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationExtension\Dependency\Plugin\ErpOrderCancellationItemPostSavePluginInterface
      */
     protected MockObject|ErpOrderCancellationItemPostSavePluginInterface $erpOrderCancellationItemReaderMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\Business\Model\Writer\ErpOrderCancellationItemWriterInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellationExtension\Dependency\Plugin\ErpOrderCancellationItemPreSavePluginInterface
      */
     protected MockObject|ErpOrderCancellationItemPreSavePluginInterface $erpOrderCancellationItemWriterMock;
 

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/Model/Writer/ErpOrderCancellationItemWriterTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/Model/Writer/ErpOrderCancellationItemWriterTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 class ErpOrderCancellationItemWriterTest extends Unit
 {
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\Business\PluginExecutor\ErpOrderCancellationPluginExecutorInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\Business\PluginExecutor\ErpOrderCancellationItemPluginExecutorInterface
      */
     protected MockObject|ErpOrderCancellationItemPluginExecutorInterface $erpOrderCancellationItemPluginExecutorMock;
 

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/Model/Writer/ErpOrderCancellationWriterTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Business/Model/Writer/ErpOrderCancellationWriterTest.php
@@ -20,7 +20,7 @@ class ErpOrderCancellationWriterTest extends Unit
     protected MockObject|LoggerInterface $loggerMock;
 
     /**
-     * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\Business\PluginExecutor\ErpOrderCancellationPluginExecutorInterface
+     * @var \PHPUnit\Framework\MockObject\MockObject|\Psr\Log\LoggerInterface
      */
     protected MockObject|LoggerInterface $erpOrderCancellationPluginExecutorMock;
 

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Communication/Plugin/PostSave/ErpOrderCancellationItemPersistorErpOrderCancellationPostSavePluginTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Communication/Plugin/PostSave/ErpOrderCancellationItemPersistorErpOrderCancellationPostSavePluginTest.php
@@ -5,6 +5,7 @@ namespace FondOfImpala\Zed\ErpOrderCancellation\Communication\Plugin\PostSave;
 use Codeception\Test\Unit;
 use FondOfImpala\Zed\ErpOrderCancellation\Business\ErpOrderCancellationFacade;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class ErpOrderCancellationItemPersistorErpOrderCancellationPostSavePluginTest extends Unit
 {

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Communication/Plugin/PreSave/GenerateCancellationReferenceErpOrderCancellationPreSavePluginTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/Communication/Plugin/PreSave/GenerateCancellationReferenceErpOrderCancellationPreSavePluginTest.php
@@ -6,6 +6,7 @@ use Codeception\Test\Unit;
 use FondOfImpala\Zed\ErpOrderCancellation\Communication\Plugin\PreSave\GenerateCancellationReferenceErpOrderCancellationPreSavePlugin;
 use FondOfImpala\Zed\ErpOrderCancellation\ErpOrderCancellationConfig;
 use Generated\Shared\Transfer\ErpOrderCancellationTransfer;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class GenerateCancellationReferenceErpOrderCancellationPreSavePluginTest extends Unit
 {
@@ -17,7 +18,7 @@ class GenerateCancellationReferenceErpOrderCancellationPreSavePluginTest extends
     /**
      * @var \PHPUnit\Framework\MockObject\MockObject|\FondOfImpala\Zed\ErpOrderCancellation\ErpOrderCancellationConfig
      */
-    protected MockObject|ErpOrderCancellationConfig $configMock;
+    protected MockObject|ErpOrderCancellationConfig $erpOrderCancellationConfigMock;
 
     /**
      * @var \FondOfImpala\Zed\ErpOrderCancellation\Communication\Plugin\PreSave\GenerateCancellationReferenceErpOrderCancellationPreSavePlugin

--- a/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/ErpOrderCancellationDependencyProviderTest.php
+++ b/bundles/erp-order-cancellation/tests/FondOfImpala/Zed/ErpOrderCancellation/ErpOrderCancellationDependencyProviderTest.php
@@ -3,6 +3,7 @@
 namespace FondOfImpala\Zed\ErpOrderCancellation;
 
 use Codeception\Test\Unit;
+use PHPUnit\Framework\MockObject\MockObject;
 use Spryker\Zed\Kernel\Container;
 
 class ErpOrderCancellationDependencyProviderTest extends Unit

--- a/bundles/permission-erp-order-cancellation-rest-api/src/FondOfImpala/Shared/PermissionErpOrderCancellationRestApi/Transfer/permission_erp_order_cancellation_rest_api.transfer.xml
+++ b/bundles/permission-erp-order-cancellation-rest-api/src/FondOfImpala/Shared/PermissionErpOrderCancellationRestApi/Transfer/permission_erp_order_cancellation_rest_api.transfer.xml
@@ -23,4 +23,9 @@
         <property name="value" type="string"/>
         <property name="comparison" type="string"/>
     </transfer>
+
+    <transfer name="ErpOrderCancellationFilter">
+        <property name="fkOriginator" type="int" />
+        <property name="debitorNumbers" singular="debitorNumber" type="array" />
+    </transfer>
 </transfers>

--- a/bundles/permission-erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/PermissionErpOrderCancellationRestApi/Communication/Plugin/ErpOrderCancellationRestApiExtension/ErpOrderCancellationCreatePermissionPluginTest.php
+++ b/bundles/permission-erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/PermissionErpOrderCancellationRestApi/Communication/Plugin/ErpOrderCancellationRestApiExtension/ErpOrderCancellationCreatePermissionPluginTest.php
@@ -88,9 +88,12 @@ class ErpOrderCancellationCreatePermissionPluginTest extends Unit
         $this->repositoryMock->expects($callCount)
             ->method('hasPermission')
             ->willReturnCallback(static function (int $id, string $permissionKey) use ($self, $callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 
@@ -126,9 +129,12 @@ class ErpOrderCancellationCreatePermissionPluginTest extends Unit
         $this->repositoryMock->expects($callCount)
             ->method('hasPermission')
             ->willReturnCallback(static function (int $id, string $permissionKey) use ($self, $callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 

--- a/bundles/permission-erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/PermissionErpOrderCancellationRestApi/Communication/Plugin/ErpOrderCancellationRestApiExtension/ErpOrderCancellationUpdatePermissionPluginTest.php
+++ b/bundles/permission-erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/PermissionErpOrderCancellationRestApi/Communication/Plugin/ErpOrderCancellationRestApiExtension/ErpOrderCancellationUpdatePermissionPluginTest.php
@@ -88,9 +88,12 @@ class ErpOrderCancellationUpdatePermissionPluginTest extends Unit
         $this->repositoryMock->expects($callCount)
             ->method('hasPermission')
             ->willReturnCallback(static function (int $id, string $permissionKey) use ($self, $callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 
@@ -130,9 +133,12 @@ class ErpOrderCancellationUpdatePermissionPluginTest extends Unit
         $this->repositoryMock->expects($callCount)
             ->method('hasPermission')
             ->willReturnCallback(static function (int $id, string $permissionKey) use ($self, $callCount) {
+                /** @phpstan-ignore-next-line */
                 if (method_exists($callCount, 'getInvocationCount')) {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->getInvocationCount();
                 } else {
+                    /** @phpstan-ignore-next-line */
                     $count = $callCount->numberOfInvocations();
                 }
 

--- a/bundles/permission-erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/PermissionErpOrderCancellationRestApi/PermissionErpOrderCancellationRestApiDependencyProviderTest.php
+++ b/bundles/permission-erp-order-cancellation-rest-api/tests/FondOfImpala/Zed/PermissionErpOrderCancellationRestApi/PermissionErpOrderCancellationRestApiDependencyProviderTest.php
@@ -29,9 +29,12 @@ class PermissionErpOrderCancellationRestApiDependencyProviderTest extends Unit
     {
         $containerMock = $this->getMockBuilder(Container::class);
 
+        /** @phpstan-ignore-next-line */
         if (method_exists($containerMock, 'setMethodsExcept')) {
+            /** @phpstan-ignore-next-line */
             $containerMock->setMethodsExcept(['factory', 'set', 'offsetSet', 'get', 'offsetGet']);
         } else {
+            /** @phpstan-ignore-next-line */
             $containerMock->onlyMethods(['getLocator'])->enableOriginalClone();
         }
 


### PR DESCRIPTION
- remove deprecated stuff from unit tests to work with latest phpunit versions 
- fix some phpstan error